### PR TITLE
[wip] Group changes in changesets

### DIFF
--- a/app/screens/Features/AddFeatureDetail.js
+++ b/app/screens/Features/AddFeatureDetail.js
@@ -125,28 +125,37 @@ class EditFeatureDetail extends React.Component {
     })
   }
 
-  cancelEditDialog = () => {
-    this.setState({ dialogVisible: false })
-  }
+  // cancelEditDialog = () => {
+  //   this.setState({ dialogVisible: false })
+  // }
 
-  saveEditDialog = async (comment) => {
-    const { navigation, addFeature, uploadEdits } = this.props
+  // saveEditDialog = async (comment) => {
+  //   const { navigation, addFeature, uploadEdits } = this.props
+  //   const { state: { params: { feature } } } = navigation
+
+  //   this.cancelEditDialog()
+  //   Keyboard.dismiss()
+
+  //   // if we don't do this, the save dialog never clears itself
+  //   await nextTick()
+
+  //   feature.properties = this.getFeatureProperties()
+
+  //   // call addFeature action with feature
+  //   addFeature(feature, comment)
+
+  //   // call action to attempt to upload the edit
+  //   uploadEdits([feature.id])
+  //   navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+  // }
+
+  saveFeature = () => {
+    const { navigation, addFeature } = this.props
     const { state: { params: { feature } } } = navigation
-
-    this.cancelEditDialog()
     Keyboard.dismiss()
-
-    // if we don't do this, the save dialog never clears itself
-    await nextTick()
-
     feature.properties = this.getFeatureProperties()
-
-    // call addFeature action with feature
-    addFeature(feature, comment)
-
-    // call action to attempt to upload the edit
-    uploadEdits([feature.id])
-    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+    addFeature(feature)
+    navigation.navigate('Explore', { mode: 'explore' })
   }
 
   isFeatureEmpty () {
@@ -382,7 +391,7 @@ class EditFeatureDetail extends React.Component {
       headerActions.push({
         name: 'tick',
         onPress: () => {
-          this.setState({ dialogVisible: true })
+          this.saveFeature()
         }
       })
     }

--- a/app/screens/Features/EditFeatureDetail.js
+++ b/app/screens/Features/EditFeatureDetail.js
@@ -16,7 +16,6 @@ import FeatureDetailHeader from '../../components/FeatureDetailHeader'
 import { getFieldInput, ReadOnlyField } from '../../components/Input'
 import objToArray from '../../utils/object-to-array'
 import { metaKeys, nonpropKeys } from '../../utils/uninterestingKeys'
-import nextTick from '../../utils/next-tick'
 import SaveEditDialog from '../../components/SaveEditDialog'
 import getFields from '../../utils/get-fields'
 import { getParentPreset } from '../../utils/get-parent-preset'
@@ -177,23 +176,32 @@ class EditFeatureDetail extends React.Component {
     this.setState({ dialogVisible: false })
   }
 
-  saveEditDialog = async (comment) => {
-    const { navigation, editFeature, uploadEdits } = this.props
+  // saveEditDialog = async (comment) => {
+  //   const { navigation, editFeature, uploadEdits } = this.props
+  //   const { state: { params: { feature } } } = navigation
+
+  //   this.cancelEditDialog()
+  //   const changesetComment = comment
+  //   Keyboard.dismiss()
+
+  //   // if we don't do this, the save dialog never clears itself
+  //   await nextTick()
+
+  //   const newFeature = this.getNewFeature()
+
+  //   editFeature(feature, newFeature, changesetComment)
+  //   uploadEdits([feature.id])
+
+  //   navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+  // }
+
+  saveFeature () {
+    const { navigation, editFeature } = this.props
     const { state: { params: { feature } } } = navigation
-
-    this.cancelEditDialog()
-    const changesetComment = comment
     Keyboard.dismiss()
-
-    // if we don't do this, the save dialog never clears itself
-    await nextTick()
-
     const newFeature = this.getNewFeature()
-
-    editFeature(feature, newFeature, changesetComment)
-    uploadEdits([feature.id])
-
-    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+    editFeature(feature, newFeature)
+    navigation.navigate('Explore', { mode: 'explore' })
   }
 
   getNewFeature () {
@@ -438,7 +446,7 @@ class EditFeatureDetail extends React.Component {
       headerActions.push({
         name: 'tick',
         onPress: () => {
-          this.setState({ dialogVisible: true })
+          this.saveFeature()
         }
       })
     }

--- a/app/screens/Features/ViewFeatureDetail.js
+++ b/app/screens/Features/ViewFeatureDetail.js
@@ -9,10 +9,8 @@ import PageWrapper from '../../components/PageWrapper'
 
 import getFeatureFields from '../../utils/get-feature-fields'
 import { metaKeys } from '../../utils/uninterestingKeys'
-import nextTick from '../../utils/next-tick'
 import _partition from 'lodash.partition'
 import orderPresets from '../../utils/order-presets'
-import SaveEditDialog from '../../components/SaveEditDialog'
 import { deleteFeature, uploadEdits } from '../../actions/edit'
 
 const FieldsList = styled.SectionList`
@@ -93,8 +91,17 @@ class ViewFeatureDetail extends React.Component {
     )
   }
 
-  render () {
+  saveDelete () {
     const { navigation, deleteFeature, uploadEdits } = this.props
+    const { state: { params: { feature } } } = navigation
+    Keyboard.dismiss()
+
+    deleteFeature(feature)
+    navigation.navigate('Explore')
+  }
+
+  render () {
+    const { navigation } = this.props
     const { state: { params: { feature } } } = navigation
 
     const title = feature.properties.name || feature.id
@@ -106,21 +113,6 @@ class ViewFeatureDetail extends React.Component {
     const metaSection = { 'title': 'Metadata', 'data': meta }
     const presetSection = { 'title': 'Attributes', 'data': orderPresets(presets) }
 
-    const cancelEditDialog = () => {
-      this.setState({ dialogVisible: false })
-    }
-
-    const saveEditDialog = async comment => {
-      cancelEditDialog()
-      Keyboard.dismiss()
-
-      await nextTick()
-
-      deleteFeature(feature, comment)
-      uploadEdits([feature.id])
-      navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
-    }
-
     const headerActions = [
       {
         name: 'pencil',
@@ -131,7 +123,7 @@ class ViewFeatureDetail extends React.Component {
       {
         name: 'trash-bin',
         onPress: () => {
-          this.setState({ dialogVisible: true })
+          this.saveDelete()
         }
       }
     ]
@@ -142,7 +134,6 @@ class ViewFeatureDetail extends React.Component {
         <PageWrapper>
           {this.renderFields([presetSection, metaSection])}
         </PageWrapper>
-        <SaveEditDialog visible={this.state.dialogVisible} cancel={cancelEditDialog} save={saveEditDialog} action='delete' />
       </Container>
     )
   }

--- a/app/screens/UserContributions/UserContributionsListScreen.js
+++ b/app/screens/UserContributions/UserContributionsListScreen.js
@@ -3,9 +3,10 @@ import { connect } from 'react-redux'
 
 import Header from '../../components/Header'
 import Container from '../../components/Container'
-
+import SaveEditDialog from '../../components/SaveEditDialog'
 import UserContributionsList from '../../components/UserContributionsList'
 import { uploadEdits, clearUploadedEdits, retryAllEdits } from '../../actions/edit'
+import { getAllRetriable } from '../../utils/edit-utils'
 
 class UserContributionsListScreen extends React.Component {
   static navigationOptions = ({ navigation }) => {
@@ -14,19 +15,37 @@ class UserContributionsListScreen extends React.Component {
     }
   }
 
+  state = {
+    dialogVisible: false
+  }
+
   select = edit => {
     const { navigation } = this.props
 
     navigation.navigate('UserContributionsDetail', { editId: edit.id, timestamp: edit.timestamp })
   }
 
-  render () {
-    const { clearUploadedEdits, navigation, edits, retryAllEdits, uploadedEdits } = this.props
+  cancelEditDialog = () => {
+    this.setState({ dialogVisible: false })
+  }
+
+  saveEdits = async (comment) => {
+    const { edits } = this.props
+    const retryableEdits = getAllRetriable(edits).map(edit => edit.id)
+    this.setState({ dialogVisible: false })
+    console.log('calling uploadEdits', retryableEdits)
+    await this.props.uploadEdits(retryableEdits, comment)
+  }
+
+  render = () => {
+    const { clearUploadedEdits, navigation, edits, uploadedEdits } = this.props
     const allEdits = edits.concat(uploadedEdits).sort((a, b) => b.timestamp > a.timestamp ? 1 : -1)
     const headerActions = [
       {
         name: 'upload-2',
-        onPress: retryAllEdits
+        onPress: () => {
+          this.setState({ dialogVisible: true })
+        }
       },
       {
         name: 'trash-bin',
@@ -43,6 +62,7 @@ class UserContributionsListScreen extends React.Component {
           data={allEdits}
           onSelectItem={this.select}
         />
+        <SaveEditDialog visible={this.state.dialogVisible} cancel={this.cancelEditDialog} save={this.saveEdits} />
 
       </Container>
     )

--- a/app/utils/upload-edit.js
+++ b/app/utils/upload-edit.js
@@ -8,6 +8,7 @@ import {
 } from '../services/api'
 
 import { version } from '../../package.json'
+
 /**
  * Takes a single edit object and creates a changeset for it and uploads it to the OSM API
  * @param {Object} edit - edit object with `id`, `oldFeature`, `newFeature`, `type`


### PR DESCRIPTION
Implements #29 

This PR so far:

 - Switches uploadEdits to accept a changeset comment and create a single changeset for all edits passed to it.
 - Change the Add, Edit and Delete Feature calls to not call `uploadEdits` automatically.
 - Switch getting the changeset comment to the `UserContributionsListScreen` when uploading a batch of changes.

You can test making some changes, going to User Contributions and uploading them, and this should ask you for a changeset comment and upload all the `Pending` uploads into a single changeset.

TODO:

 - [ ] Do not automatically retry uploading on Authorization or coming Online
 - [ ] Hide Upload All button on User Contributions List if user is not online or not authorized. (we will probably want to show this to the user somewhere on this page). Alternatively, keep the button, but just show an error like "Not Authorized" or "Not Online" when user clicks it.
 - [ ] Either disable uploading individual changes in the UserContributionDetail screen or ask user for a changeset comment when uploading there.
 - [ ] Remove a bunch of console.logs
 - [ ] Remove commented out code, clean up some unused functions and code paths

cc @geohacker @sethvincent @mojodna - will continue working on the TODOs above - let me know if anyone has any feedback - thanks!