### PR TITLE
Coordinates is always an array

### DIFF
--- a/app/screens/Features/EditFeatureDetail.js
+++ b/app/screens/Features/EditFeatureDetail.js
@@ -202,9 +202,9 @@ class EditFeatureDetail extends React.Component {
       ...feature,
       geometry: {
         ...feature.geometry,
-        coordinates: {
+        coordinates: [
           ...feature.geometry.coordinates
-        }
+        ]
       },
       properties: {
         ...feature.properties


### PR DESCRIPTION
Looks like the coordinates weren't spread properly for copying to the new feature. Fixes #68  and #63. 