### PR TITLE
set the initial zoom level of the map to 12

### DIFF
--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -402,7 +402,7 @@ class Explore extends React.Component {
             minZoomLevel={2}
             maxZoomLevel={19}
             ref={(ref) => { this.mapRef = ref }}
-            zoomLevel={18}
+            zoomLevel={12}
             showUserLocation
             onUserLocationUpdate={this.onUserLocationUpdate}
             userTrackingMode={userTrackingMode}


### PR DESCRIPTION
Fixes #71 
Instead of setting an initial map center we can just set the zoom to be lower than editable zoom. 