### PR TITLE
Fix build-styles task

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,8 @@
 MAPBOX_ACCESS_TOKEN=<your_mapbox_access_token>
 MAPBOX_STYLE_URL=osm.json
 MAPBOX_SATELLITE_STYLE_URL=satellite.json
-REMOTE_MAPBOX_STYLE_URL=<remote URL>
-REMOTE_SATELLITE_STYLE_URL=<remote URL>
+REMOTE_MAPBOX_STYLE_URL=<remote_URL>
+REMOTE_SATELLITE_STYLE_URL=<remote_URL>
 
 OSM_TILE_URL=https://a.tile.openstreetmap.org/{z}/{x}/{y}.png
 OSM_LAYER_NAME='OpenStreetMap'


### PR DESCRIPTION
While trying to setup I got the following error when running `yarn build-styles`:

```
~/dev/observe/mobile$ yarn build-styles
yarn run v1.13.0
$ export $(cat .env | grep '^[^#;]' | xargs) && envsubst '${OSM_TILE_URL}' < app/assets/osm.json.template > app/assets/osm.json && envsubst '${SATELLITE_TILE_URL} ${SATELLITE_TILE_SIZE}' < app/assets/satellite.json.template > app/assets/satellite.json
/bin/sh: line 0: export: `URL>': not a valid identifier
/bin/sh: line 0: export: `URL>': not a valid identifier
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The `export...` command defines values to env vars. Some placeholder values included a space, which broke the command. I've replaced them by underscores and now the task `build-styles` run properly.

