### PR TITLE
Fix field collapse in add/edit feature panel

### DIFF
--- a/app/components/Input.js
+++ b/app/components/Input.js
@@ -14,6 +14,7 @@ const FieldWrapper = styled.View`
   margin-top: 16;
   flex: 1;
   flex-direction: row;
+  flex-shrink: 0;
 `
 
 const LabelWrapper = styled.View`


### PR DESCRIPTION
Set `flex-shrink: 0` on FieldWrapper input to fix #26

@sethvincent can you test this on iOS?