### PR TITLE
improve preath & location access flow

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { AppState } from 'react-native'
 import Config from 'react-native-config'
 import { Provider } from 'react-redux'
 
@@ -27,7 +26,6 @@ import ObserveAPIAuthManager from './app/components/ObserveAPIAuthManager'
 import CameraScreen from './app/screens/CameraScreen'
 import SaveTrace from './app/screens/SaveTrace'
 
-import { preAuth } from './app/services/auth'
 import { ReduxNetworkProvider } from 'react-native-offline'
 import Icon from './app/components/Collecticons'
 import { colors } from './app/style/variables'
@@ -123,23 +121,7 @@ const AppNavigator = createDrawerNavigator({
 
 const AppContainer = createAppContainer(AppNavigator)
 
-// FIXME: we should pass a <Loading /> component to loading= on the PersistGate to show while app state is being loaded
-// from persistent store
 export default class App extends Component {
-  _handleAppStateChange (nextState) {
-    if (nextState === 'active') {
-      preAuth()
-    }
-  }
-
-  componentWillMount () {
-    AppState.addEventListener('change', this._handleAppStateChange)
-  }
-
-  componentWillUnmount () {
-    AppState.removeEventListener('change', this._handleAppStateChange)
-  }
-
   render () {
     return (
       <Provider store={store}>

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -145,8 +145,12 @@ class Explore extends React.Component {
   }
 
   onDidFocus = () => {
-    this.forceUpdate()
-    this.locateUser()
+    const { requiresPreauth } = this.props
+
+    if (!requiresPreauth) {
+      this.forceUpdate()
+      this.locateUser()
+    }
   }
 
   onWillStartLoadingMap = () => {
@@ -197,10 +201,14 @@ class Explore extends React.Component {
     try {
       const userLocation = await getUserLocation()
       if (userLocation.hasOwnProperty('coords')) {
-        this.cameraRef.setCamera({
-          centerCoordinate: [userLocation.coords.longitude, userLocation.coords.latitude],
+        const centerCoordinate = [userLocation.coords.longitude, userLocation.coords.latitude]
+
+        this.cameraRef && this.cameraRef.setCamera({
+          centerCoordinate,
           zoomLevel: 18
         })
+
+        this.setState({ centerCoordinate })
       }
     } catch (error) {
       console.log('error fetching user location', error)
@@ -330,6 +338,7 @@ class Explore extends React.Component {
       <AuthMessage onPress={async () => {
         await authorize()
         await this.props.loadUserDetails()
+        this.locateUser()
       }} />
     )
   }
@@ -343,7 +352,7 @@ class Explore extends React.Component {
       mode,
       currentTraceStatus,
       currentTrace,
-      userDetails,
+      requiresPreauth,
       tracesGeojson,
       style
     } = this.props
@@ -536,7 +545,7 @@ class Explore extends React.Component {
             title={this.getTitle()}
           />
           {
-            Config.PREAUTH_URL && !userDetails
+            requiresPreauth
               ? this.renderAuthPrompt()
               : (
                 <StyledMap
@@ -554,7 +563,7 @@ class Explore extends React.Component {
                 >
                   <MapboxGL.Camera zoomLevel={12}
                     defaultSettings={{
-                      centerCoordinate: [77.5946, 12.9716],
+                      centerCoordinate: [0, 0],
                       zoomLevel: 12
                     }}
                     ref={(ref) => { this.cameraRef = ref }}
@@ -603,27 +612,32 @@ class Explore extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  geojson: getVisibleFeatures(state),
-  isTracing: getIsTracing(state),
-  currentTrace: getCurrentTraceGeoJSON(state),
-  currentTraceLength: getCurrentTraceLength(state),
-  currentTraceStatus: getCurrentTraceStatus(state),
-  isConnected: state.network.isConnected,
-  selectedFeatures: state.map.selectedFeatures || false,
-  mode: state.map.mode,
-  edits: state.edit.edits,
-  editsGeojson: state.edit.editsGeojson,
-  loadingData: isLoadingData(state),
-  visibleBounds: getVisibleBounds(state),
-  zoom: getZoom(state),
-  baseLayer: state.map.baseLayer,
-  isAuthorized: state.authorization.isAuthorized,
-  userDetails: state.account.userDetails,
-  tracesGeojson: getTracesGeojson(state),
-  overlays: state.map.overlays,
-  style: state.map.style
-})
+const mapStateToProps = (state) => {
+  const { userDetails } = state.account
+
+  return {
+    geojson: getVisibleFeatures(state),
+    isTracing: getIsTracing(state),
+    currentTrace: getCurrentTraceGeoJSON(state),
+    currentTraceLength: getCurrentTraceLength(state),
+    currentTraceStatus: getCurrentTraceStatus(state),
+    isConnected: state.network.isConnected,
+    selectedFeatures: state.map.selectedFeatures || false,
+    mode: state.map.mode,
+    edits: state.edit.edits,
+    editsGeojson: state.edit.editsGeojson,
+    loadingData: isLoadingData(state),
+    visibleBounds: getVisibleBounds(state),
+    zoom: getZoom(state),
+    baseLayer: state.map.baseLayer,
+    isAuthorized: state.authorization.isAuthorized,
+    userDetails,
+    requiresPreauth: Config.PREAUTH_URL && !userDetails,
+    tracesGeojson: getTracesGeojson(state),
+    overlays: state.map.overlays,
+    style: state.map.style
+  }
+}
 
 const mapDispatchToProps = {
   fetchData,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react": "16.9.0",
     "react-native": "0.61.1",
     "react-native-config": "^0.11.7",
-    "react-native-cookies": "developmentseed/react-native-cookies#3fec1ad",
+    "react-native-cookies": "developmentseed/react-native-cookies#f394a7a",
     "react-native-datepicker": "^1.7.2",
     "react-native-dialog": "^5.6.0",
     "react-native-geolocation-service": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7820,9 +7820,9 @@ react-native-config@^0.11.7:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-0.11.7.tgz#a2b323f2ecd76a4df88cbb6bc86eaa2ef9febee7"
   integrity sha512-dn5s+zhwLyE25vRT/vaEtLk/j8ZL1UZKvejORNDWakSwpOnLmFurFeaZV83IqkPlfWHXHFdsYe2IRYG1WN4WkQ==
 
-react-native-cookies@developmentseed/react-native-cookies#3fec1ad:
+react-native-cookies@developmentseed/react-native-cookies#f394a7a:
   version "3.3.0"
-  resolved "https://codeload.github.com/developmentseed/react-native-cookies/tar.gz/3fec1ad23e5c3d6829dccdf8ba0db10c97916b9d"
+  resolved "https://codeload.github.com/developmentseed/react-native-cookies/tar.gz/f394a7ae7b8cf42f3baf950fde6a3447ed93e73e"
   dependencies:
     invariant "^2.1.0"
 


### PR DESCRIPTION
With these changes the preauth flow is working much smoother on devices. I think there was a conflict between preauth and `onDidFocus` where the rerender would end up making the user do preauth twice? That's my impression, anyway, and guarding against that in `onDidFocus` has resolved the issue I was seeing.