### PR TITLE
add observe api auth to accounts screen

### DIFF
--- a/app/screens/Account.js
+++ b/app/screens/Account.js
@@ -5,10 +5,11 @@ import Header from '../components/Header'
 import Container from '../components/Container'
 import Icon from '../components/Collecticons'
 import { loadUserDetails, initiateAuthorization, reset } from '../actions/account'
-import { View } from 'react-native'
+import { View, Linking } from 'react-native'
 import PageWrapper from '../components/PageWrapper'
 import LoadingOverlay from '../components/LoadingOverlay'
 import { colors } from '../style/variables'
+import Config from 'react-native-config'
 
 const Text = styled.Text`
 `
@@ -22,11 +23,13 @@ const Image = styled.Image`
   overflow: hidden;
 `
 
-const OfflineView = styled.View`
+const AccountView = styled.View`
   flex: 1;
+  margin-top: 30px;
   align-items: center;
   justify-content: center;
 `
+
 const AccountIcon = styled.Text`
   padding-bottom: 10;
 `
@@ -76,6 +79,12 @@ class Account extends React.Component {
     this.props.loadUserDetails()
   }
 
+  apiLogin = () => {
+    const redirectURL = 'observe://apilogin'
+    const loginURL = `${Config.OBSERVE_API_URL}/login?redirect=${redirectURL}`
+    Linking.openURL(loginURL).catch(e => console.log('error opening url', e))
+  }
+
   renderDetail (detail) {
     return (
       <Field>
@@ -102,18 +111,80 @@ class Account extends React.Component {
         detailsList.push({ 'key': keyLabelMap[k], 'value': details[k] })
       }
     })
+
+    let showImage = null
+    if (details.image) {
+      showImage = (
+        <ImageView>
+          <Image
+            style={{ width: 100, height: 100 }}
+            source={{ uri: details.image }}
+          />
+        </ImageView>
+      )
+    }
     return (
-      <DetailsList
-        data={detailsList}
-        renderItem={({ item }) => this.renderDetail(item)}
-        keyExtractor={(item) => item.value}
-      />
+      <PageWrapper>
+        {showImage}
+        <DetailsList
+          data={detailsList}
+          renderItem={({ item }) => this.renderDetail(item)}
+          keyExtractor={(item) => item.value}
+        />
+      </PageWrapper>
     )
   }
+
+  renderOSMDetails (userDetails) {
+    if (userDetails) {
+      return this.renderDetails(userDetails)
+    } else {
+      return (
+        <AccountView>
+          <AccountIcon>
+            <Icon name='user' size={30} color='grey' />
+          </AccountIcon>
+          <Text>It seems that you're not logged in.</Text>
+          <Text style={{ marginBottom: 8 }}>Do you have an account?</Text>
+          <LoginButton
+            title='Log in'
+            onPress={this.props.initiateAuthorization}
+            color={colors.primary}
+          />
+        </AccountView>
+      )
+    }
+  }
+
+  renderObserveApiDetails () {
+    const { observeApi } = this.props
+    console.log('observeApi', observeApi)
+    if (!observeApi) {
+      return (
+        <AccountView>
+          <Text>Observe API is not connected.</Text>
+          <Text>Authorize to upload photos and traces.</Text>
+          <LoginButton
+            title='Authorize'
+            onPress={this.apiLogin}
+            color={colors.primary}
+          />
+        </AccountView>
+      )
+    } else {
+      return (
+        <PageWrapper>
+          <Icon name='circle-tick' size={30} color='blue' />
+          <Text style={{ marginTop: 10 }}>Observe API authorized.
+          </Text>
+        </PageWrapper>
+      )
+    }
+  }
+
   render () {
     const { navigation } = this.props
     const { userDetails } = this.props
-
     let showLoadingIndicator = null
     if (this.props.loadingDetails) {
       showLoadingIndicator = (
@@ -129,53 +200,23 @@ class Account extends React.Component {
         }
       }
     ]
-    if (userDetails) {
-      return (
-        <Container>
-          <Header navigation={navigation} actions={headerActions} />
-          <PageWrapper>
-            {
-              userDetails.image && (
-                <ImageView>
-                  <Image
-                    style={{ width: 100, height: 100 }}
-                    source={{ uri: userDetails.image }}
-                  />
-                </ImageView>
-              )
-            }
-            {this.renderDetails(userDetails)}
-          </PageWrapper>
-        </Container>
-      )
-      // render userDetails
-    } else {
-      return (
-        <Container>
-          <Header navigation={navigation} />
-          <OfflineView>
-            <AccountIcon>
-              <Icon name='user' size={30} color='grey' />
-            </AccountIcon>
-            <Text>It seems that you're not logged in.</Text>
-            <Text style={{ marginBottom: 8 }}>Do you have an account?</Text>
-            <LoginButton
-              title='Log in'
-              onPress={this.props.initiateAuthorization}
-              color={colors.primary}
-            />
-            {showLoadingIndicator}
-          </OfflineView>
-        </Container>
-      )
-    }
+
+    return (
+      <Container>
+        <Header title='Account' navigation={navigation} actions={headerActions} />
+        {this.renderOSMDetails(userDetails)}
+        {this.renderObserveApiDetails()}
+        {showLoadingIndicator}
+      </Container>
+    )
   }
 }
 
 const mapStateToProps = state => {
   return {
     userDetails: state.account.userDetails,
-    loadingDetails: state.account.loadingDetails
+    loadingDetails: state.account.loadingDetails,
+    observeApi: state.observeApi.token || false
   }
 }
 

--- a/app/screens/Account.js
+++ b/app/screens/Account.js
@@ -28,6 +28,7 @@ const AccountView = styled.View`
   margin-top: 30px;
   align-items: center;
   justify-content: center;
+  height: 200;
 `
 
 const AccountIcon = styled.Text`
@@ -60,6 +61,12 @@ const LoginButton = styled.Button`
 
 const DetailsList = styled.FlatList`
   padding-top: 10;
+`
+
+const ObserveDetailsView = styled.View`
+  flex-direction: row;
+  align-content: center;
+  align-items: center;
 `
 
 class Account extends React.Component {
@@ -124,14 +131,14 @@ class Account extends React.Component {
       )
     }
     return (
-      <PageWrapper>
+      <>
         {showImage}
         <DetailsList
           data={detailsList}
           renderItem={({ item }) => this.renderDetail(item)}
           keyExtractor={(item) => item.value}
         />
-      </PageWrapper>
+      </>
     )
   }
 
@@ -163,7 +170,7 @@ class Account extends React.Component {
       return (
         <AccountView>
           <Text>Observe API is not connected.</Text>
-          <Text>Authorize to upload photos and traces.</Text>
+          <Text style={{ marginBottom: 8 }}>Authorize to upload photos and traces.</Text>
           <LoginButton
             title='Authorize'
             onPress={this.apiLogin}
@@ -173,11 +180,11 @@ class Account extends React.Component {
       )
     } else {
       return (
-        <PageWrapper>
+        <ObserveDetailsView>
           <Icon name='circle-tick' size={30} color='blue' />
-          <Text style={{ marginTop: 10 }}>Observe API authorized.
+          <Text style={{ marginLeft: 10 }}>Observe API authorized.
           </Text>
-        </PageWrapper>
+        </ObserveDetailsView>
       )
     }
   }
@@ -204,9 +211,11 @@ class Account extends React.Component {
     return (
       <Container>
         <Header title='Account' navigation={navigation} actions={headerActions} />
-        {this.renderOSMDetails(userDetails)}
-        {this.renderObserveApiDetails()}
-        {showLoadingIndicator}
+        <PageWrapper>
+          {this.renderOSMDetails(userDetails)}
+          {this.renderObserveApiDetails()}
+          {showLoadingIndicator}
+        </PageWrapper>
       </Container>
     )
   }

--- a/app/screens/Settings.js
+++ b/app/screens/Settings.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components/native'
 import { purgeCache, purgeStore, purgeCookies } from '../actions/about'
 import { purgeAllEdits } from '../actions/edit'
+import { logoutUser } from '../actions/observeApi'
 import Icon from '../components/Collecticons'
 import Header from '../components/Header'
 import PageWrapper from '../components/PageWrapper'
@@ -75,6 +76,13 @@ class Settings extends React.Component {
           </ButtonWrapper>
           <ButtonWrapper>
             <Button
+              onPress={this.props.logoutUser}
+              title='Clear Observe API Token'
+              color={colors.primary}
+            />
+          </ButtonWrapper>
+          <ButtonWrapper>
+            <Button
               onPress={this.props.purgeCookies}
               title='Delete Cookies'
               color={colors.primary}
@@ -97,7 +105,8 @@ const mapDispatchToProps = {
   purgeCache,
   purgeStore,
   purgeCookies,
-  purgeAllEdits
+  purgeAllEdits,
+  logoutUser
 }
 
 export default connect(

--- a/app/screens/Settings.js
+++ b/app/screens/Settings.js
@@ -1,12 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components/native'
-import { Linking } from 'react-native'
-import Config from 'react-native-config'
 import { purgeCache, purgeStore, purgeCookies } from '../actions/about'
 import { purgeAllEdits } from '../actions/edit'
-import { startTrace, endTrace } from '../actions/traces'
-import { getProfile } from '../actions/observeApi'
 import Icon from '../components/Collecticons'
 import Header from '../components/Header'
 import PageWrapper from '../components/PageWrapper'
@@ -48,12 +44,6 @@ class Settings extends React.Component {
     }
   }
 
-  apiLogin = () => {
-    const redirectURL = 'observe://apilogin'
-    const loginURL = `${Config.OBSERVE_API_URL}/login?redirect=${redirectURL}`
-    Linking.openURL(loginURL).catch(e => console.log('error opening url', e))
-  }
-
   render () {
     const { navigation } = this.props
 
@@ -90,34 +80,6 @@ class Settings extends React.Component {
               color={colors.primary}
             />
           </ButtonWrapper>
-          <ButtonWrapper>
-            <Button
-              onPress={this.props.startTrace}
-              title='Start Trace'
-              color={colors.primary}
-              disabled={!!this.props.currentTrace}
-            />
-            <Button
-              onPress={this.props.endTrace}
-              title='End Trace'
-              color={colors.primary}
-              disabled={!this.props.currentTrace}
-            />
-          </ButtonWrapper>
-          <ButtonWrapper>
-            <Button
-              onPress={this.apiLogin}
-              title='Login to Observe API'
-              color={colors.primary}
-            />
-          </ButtonWrapper>
-          <ButtonWrapper>
-            <Button
-              onPress={this.props.getProfile}
-              title='Get Observe API Profile'
-              color={colors.primary}
-            />
-          </ButtonWrapper>
           <Text>
             Observe-{version}
           </Text>
@@ -135,10 +97,7 @@ const mapDispatchToProps = {
   purgeCache,
   purgeStore,
   purgeCookies,
-  purgeAllEdits,
-  startTrace,
-  endTrace,
-  getProfile
+  purgeAllEdits
 }
 
 export default connect(


### PR DESCRIPTION
This PR adds Observe API authorization to the accounts screen. So now both OSM API and Observe API can be controlled from the same screen.