### PR TITLE
make android accept strings in version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -114,7 +114,7 @@ android {
         applicationId "com.developmentseed.observe"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
+        versionCode versionMajor * 10000 + versionMinor * 100
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         setProperty("archivesBaseName", "observe" + "-v" + versionName)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,5 +64,5 @@ def getNpmVersion() {
 
 def getNpmVersionArray() { // major [0], minor [1], patch [2]
     def (major, minor, patch) = getNpmVersion().tokenize('.')
-    return [Integer.parseInt(major), Integer.parseInt(minor), Integer.parseInt(patch)] as int[]
+    return [Integer.parseInt(major), Integer.parseInt(minor), patch]
 }


### PR DESCRIPTION
this PR changes how android build parses the version strings. previously, patches also had to be integers. we want to introduce alpha and rc release so this allows support for that.