### PR TITLE
fix map maxzoom so tiles don't go black

### DIFF
--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -591,7 +591,9 @@ class Explore extends React.Component {
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}
                   >
-                    <MapboxGL.Camera zoomLevel={12}
+                    <MapboxGL.Camera
+                      zoomLevel={12}
+                      maxZoomLevel={19}
                       defaultSettings={{
                         centerCoordinate: [0, 0],
                         zoomLevel: 12


### PR DESCRIPTION
As reported while testing, the default OSM tiles go blank after 19. I thought the [style definition](https://github.com/developmentseed/observe/blob/fix/maxzoom/app/assets/osm.json.template#L17-L18) would take care of this -- so this is a quick fix. 