### PR TITLE
add/edit way mode

### DIFF
--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -50,7 +50,7 @@ describe('map reducer', () => {
       type: 'START_ADD_POINT'
     }
     const newState = reducer(mockState, action)
-    expect(newState.mode).toEqual('add')
+    expect(newState.mode).toEqual(modes.ADD_POINT)
   })
 
   it('should set mode to explore on MAP_BACK_PRESS', () => {
@@ -62,6 +62,6 @@ describe('map reducer', () => {
       type: 'MAP_BACK_PRESS'
     }
     const newState = reducer(mockState, action)
-    expect(newState.mode).toEqual('explore')
+    expect(newState.mode).toEqual(modes.EXPLORE)
   })
 })

--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -5,12 +5,13 @@
 import reducer from '../../app/reducers/map'
 import { featureCollection } from '@turf/helpers'
 import { getFeature } from '../test-utils'
+import { modes } from '../../app/utils/map-modes'
 
 function getInitialState () {
   return {
     activeTileRequests: new Set(),
     fetchedTiles: {},
-    mode: 'explore',
+    mode: modes.EXPLORE,
     visibleBounds: [[-180, -90, 180, 90]]
   }
 }
@@ -55,7 +56,7 @@ describe('map reducer', () => {
   it('should set mode to explore on MAP_BACK_PRESS', () => {
     const mockState = {
       ...getInitialState(),
-      mode: 'add'
+      mode: modes.ADD_POINT
     }
     const action = {
       type: 'MAP_BACK_PRESS'

--- a/app/components/AddPointButton.js
+++ b/app/components/AddPointButton.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import { Dimensions } from 'react-native'
 import styled from 'styled-components/native'
-
+import { Dimensions } from 'react-native'
 import Icon from './Collecticons'
-
 import { colors } from '../style/variables'
 
 const win = Dimensions.get('window')
@@ -11,23 +9,25 @@ const win = Dimensions.get('window')
 const Button = styled.TouchableHighlight`
   position: absolute;
   border-radius: ${Math.round(win.width + win.height) / 2};
-  width: 56;
-  height: 56;
+  width: 48;
+  height: 48;
   background-color: ${colors.primary};
   right: 16;
-  bottom: 16;
+  bottom: 80;
   justify-content: center;
   align-items: center;
-  shadow-color: grey;
+  shadow-color: ${colors.baseAlpha};
   shadow-opacity: 0.7;
   shadow-offset: 0px 0px;
+  elevation: 1;
 `
 
-export default class AddButton extends React.Component {
+export class AddPointButton extends React.Component {
   render () {
+    // TODO: use a more appropriate icon rather than a share icon, but hey it looks close to right
     return (
       <Button underlayColor='#333' onPress={this.props.onPress}>
-        <Icon name={this.props.icon} size={16} color='white' />
+        <Icon name='marker' size={20} color='#FFFFFF' />
       </Button>
     )
   }

--- a/app/components/AddWayButton.js
+++ b/app/components/AddWayButton.js
@@ -13,7 +13,7 @@ const Button = styled.TouchableHighlight`
   height: 48;
   background-color: ${colors.primary};
   right: 16;
-  bottom: 188;
+  bottom: 136;
   justify-content: center;
   align-items: center;
   shadow-color: ${colors.baseAlpha};
@@ -22,7 +22,7 @@ const Button = styled.TouchableHighlight`
   elevation: 1;
 `
 
-export class WayButton extends React.Component {
+export class AddWayButton extends React.Component {
   render () {
     // TODO: use a more appropriate icon rather than a share icon, but hey it looks close to right
     return (

--- a/app/components/AddWayOverlay.js
+++ b/app/components/AddWayOverlay.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import {
+  Platform
+} from 'react-native'
+import styled from 'styled-components/native'
+
+import ActionButton from '../components/ActionButton'
+import CrossHairOverlay from './CrosshairOverlay'
+
+const Container = styled.View`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+`
+
+class AddWayOverlay extends Component {
+  render () {
+    return (
+      <Container pointerEvents={Platform.OS === 'ios' ? 'box-none' : 'auto'}>
+        <CrossHairOverlay />
+        <ActionButton icon='tick' onPress={() => this.props.onAddConfirmPress()} />
+      </Container>
+    )
+  }
+}
+
+export default AddWayOverlay

--- a/app/components/CameraButton.js
+++ b/app/components/CameraButton.js
@@ -13,7 +13,7 @@ const Button = styled.TouchableHighlight`
   height: 48;
   background-color: ${colors.primary};
   right: 16;
-  bottom: 74;
+  bottom: 192;
   justify-content: center;
   align-items: center;
   shadow-color: grey;

--- a/app/components/EditWayOverlay.js
+++ b/app/components/EditWayOverlay.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import {
+  Platform
+} from 'react-native'
+import styled from 'styled-components/native'
+
+import ActionButton from '../components/ActionButton'
+import CrossHairOverlay from './CrosshairOverlay'
+
+const Container = styled.View`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+`
+
+class EditWayOverlay extends Component {
+  render () {
+    return (
+      <Container pointerEvents={Platform.OS === 'ios' ? 'box-none' : 'auto'}>
+        <CrossHairOverlay />
+        <ActionButton icon='tick' onPress={() => this.props.onAddConfirmPress()} />
+      </Container>
+    )
+  }
+}
+
+export default EditWayOverlay

--- a/app/components/FeatureDetailHeader.js
+++ b/app/components/FeatureDetailHeader.js
@@ -6,6 +6,7 @@ import ObserveIcon from './ObserveIcon'
 import { colors } from '../style/variables'
 import getDefaultPreset from '../utils/get-default-preset'
 import getPresetByTags from '../utils/get-preset-by-tags'
+import { modes } from '../utils/map-modes'
 
 const Header = styled.View`
   padding-top: 16;
@@ -94,7 +95,7 @@ export default class FeatureDetailHeader extends React.Component {
               geometryType === 'Point' && (
                 <Button
                   onPress={() => {
-                    navigation.navigate('Explore', { feature, mode: 'edit' })
+                    navigation.navigate('Explore', { feature, mode: modes.EDIT_POINT })
                   }}
                 >
                   <Coordinates>

--- a/app/components/RecordButton.js
+++ b/app/components/RecordButton.js
@@ -13,7 +13,7 @@ const Button = styled.TouchableHighlight`
   height: 48;
   background-color: ${colors.primary};
   right: 16;
-  bottom: 132;
+  bottom: 248;
   justify-content: center;
   align-items: center;
   shadow-color: ${colors.baseAlpha};

--- a/app/components/WayButton.js
+++ b/app/components/WayButton.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import styled from 'styled-components/native'
+import { Dimensions } from 'react-native'
+import Icon from './Collecticons'
+import { colors } from '../style/variables'
+
+const win = Dimensions.get('window')
+
+const Button = styled.TouchableHighlight`
+  position: absolute;
+  border-radius: ${Math.round(win.width + win.height) / 2};
+  width: 48;
+  height: 48;
+  background-color: ${colors.primary};
+  right: 16;
+  bottom: 188;
+  justify-content: center;
+  align-items: center;
+  shadow-color: ${colors.baseAlpha};
+  shadow-opacity: 0.7;
+  shadow-offset: 0px 0px;
+  elevation: 1;
+`
+
+export class WayButton extends React.Component {
+  render () {
+    // TODO: use a more appropriate icon rather than a share icon, but hey it looks close to right
+    return (
+      <Button underlayColor='#333' onPress={this.props.onPress}>
+        <Icon name='share-2' size={20} color='#FFFFFF' />
+      </Button>
+    )
+  }
+}

--- a/app/reducers/map.js
+++ b/app/reducers/map.js
@@ -5,12 +5,13 @@ import * as types from '../actions/actionTypes'
 import _uniqBy from 'lodash.uniqby'
 import style from '../style/map'
 import _cloneDeep from 'lodash.clonedeep'
+import { modes } from '../utils/map-modes'
 
 export const initialState = {
   activeTileRequests: [], // quadkeys of all pending tile requests
   fetchedTiles: {}, // Object with mapping of tiles to their respective GeoJSON FeatureCollections
   selectedFeature: false, // GeoJSON feature that is currently selected, or false
-  mode: 'explore', // mode can be 'explore', 'add' or 'edit'
+  mode: modes.EXPLORE, // see app/utils/map-modes.js for all modes
   baseLayer: null,
   overlays: {
     osm: true,
@@ -246,7 +247,7 @@ export default function (state = initialState, action) {
     case types.START_ADD_POINT:
       return {
         ...state,
-        mode: 'add'
+        mode: modes.ADD_POINT
       }
 
     // Currently, back on map is only triggered when the user is not in Explore mode.
@@ -255,7 +256,7 @@ export default function (state = initialState, action) {
     case types.MAP_BACK_PRESS:
       return {
         ...state,
-        mode: 'explore'
+        mode: modes.EXPLORE
       }
 
     case types.SET_MAP_MODE:

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -67,9 +67,12 @@ import Icon from '../components/Collecticons'
 import { colors } from '../style/variables'
 import { CameraButton } from '../components/CameraButton'
 import { RecordButton } from '../components/RecordButton'
+import { WayButton } from '../components/WayButton'
 
 import icons from '../assets/icons'
 import { authorize } from '../services/auth'
+
+import { modes, modeTitles } from '../utils/map-modes'
 
 let osmStyleURL = Config.MAPBOX_STYLE_URL || MapboxGL.StyleURL.Street
 let satelliteStyleURL = Config.MAPBOX_SATELLITE_STYLE_URL || MapboxGL.StyleURL.Satellite
@@ -284,7 +287,7 @@ class Explore extends React.Component {
 
   onBackButtonPress = () => {
     const { mode } = this.props
-    if (mode === 'explore') { // let default back handling happen when in Explore mode
+    if (mode === modes.EXPLORE) { // let default back handling happen when in Explore mode
       return false
     }
     this.props.mapBackPress()
@@ -305,12 +308,19 @@ class Explore extends React.Component {
 
   getBackButton = () => {
     const { navigation, mode } = this.props
+    const useBackButtonPress = (
+      mode === modes.ADD_POINT ||
+      mode === modes.EDIT_POINT ||
+      mode === modes.ADD_WAY ||
+      mode === modes.EDIT_WAY
+    )
+
     switch (true) {
       case navigation.getParam('back'):
         return navigation.getParam('back')
-      case mode === 'add' || mode === 'edit':
+      case useBackButtonPress:
         return this.onBackButtonPress
-      case mode === 'bbox':
+      case mode === modes.OFFLINE_MAPS:
         return 'OfflineMaps'
       default:
         return false
@@ -319,18 +329,9 @@ class Explore extends React.Component {
 
   getTitle = () => {
     const { navigation, mode } = this.props
-    switch (true) {
-      case navigation.getParam('title'):
-        return navigation.getParam('title')
-      case mode === 'add':
-        return 'Add Point'
-      case mode === 'edit':
-        return 'Edit Point'
-      case mode === 'bbox':
-        return 'Select Bounds'
-      default:
-        return 'Observe'
-    }
+    const title = navigation.getParam('title') || modeTitles[mode]
+    if (!title) return 'Observe'
+    return title
   }
 
   onRecordPress = () => {
@@ -357,6 +358,37 @@ class Explore extends React.Component {
         await this.props.loadUserDetails()
         this.locateUser()
       }} />
+    )
+  }
+
+  renderOverlay () {
+    const { navigation, geojson, mode } = this.props
+
+    if (mode === modes.OFFLINE_TILES) {
+      return null
+    }
+
+    if (mode === modes.ADD_POINT || mode === modes.EDIT_POINT) {
+      return <AddPointOverlay
+        onAddConfirmPress={this.onAddConfirmPress}
+      />
+    }
+
+    if (mode === modes.ADD_WAY || mode === modes.EDIT_WAY) {
+      // TODO: implement WayOverlay.js
+      return null
+    }
+
+    // if not in explicit mode, render default MapOverlay
+    return (
+      <>
+        <MapOverlay
+          features={geojson.features}
+          onAddButtonPress={this.onAddButtonPress}
+          navigation={navigation}
+        />
+        <ActionButton icon='plus' onPress={() => this.onAddButtonPress()} />
+      </>
     )
   }
 
@@ -409,36 +441,6 @@ class Explore extends React.Component {
         this.getFeatureType(feature) === 'node' ? filteredFeatureIds.nodes[2].push(feature.id) : filteredFeatureIds.ways[2].push(feature.id)
         return filteredFeatureIds
       }, filteredFeatureIds)
-    }
-
-    let overlay
-    switch (mode) {
-      case 'add':
-        overlay = (<AddPointOverlay
-          onAddConfirmPress={this.onAddConfirmPress}
-        />)
-        break
-
-      case 'edit':
-        overlay = (<AddPointOverlay
-          onAddConfirmPress={this.onEditConfirmPress}
-        />)
-        break
-
-      case 'bbox':
-        break
-
-      default:
-        overlay = (
-          <>
-            <MapOverlay
-              features={geojson.features}
-              onAddButtonPress={this.onAddButtonPress}
-              navigation={navigation}
-            />
-            <ActionButton icon='plus' onPress={() => this.onAddButtonPress()} />
-          </>
-        )
     }
 
     let styleURL
@@ -557,13 +559,13 @@ class Explore extends React.Component {
               // reset params once this screen has been used in bbox mode
               navigation.setParams({
                 back: null,
-                mode: 'explore',
+                mode: modes.EXPLORE,
                 title: null,
                 actions: null
               })
 
               // reset map mode
-              this.props.setMapMode('explore')
+              this.props.setMapMode(modes.EXPLORE)
             }
           }}
         />
@@ -640,11 +642,12 @@ class Explore extends React.Component {
             { showLoadingIndicator }
             <LocateUserButton onPress={() => this.locateUser()} />
             <BasemapModal onChange={this.props.setBasemap} />
+            <WayButton onPress={() => { this.props.setMapMode(modes.ADD_WAY) }} />
             <CameraButton onPress={() => navigation.navigate('CameraScreen', { previousScreen: 'Explore', feature: null })} />
             <RecordButton status={currentTraceStatus} onPress={() => this.onRecordPress()} />
             {mode !== 'bbox' && this.renderZoomToEdit()}
           </MainBody>
-          { overlay }
+          { this.renderOverlay() }
         </Container>
       </AndroidBackHandler>
     )

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components/native'
-import { Platform } from 'react-native'
+import { Platform, View, Animated } from 'react-native'
 import MapboxGL from '@react-native-mapbox-gl/maps'
 import { AndroidBackHandler } from 'react-navigation-backhandler'
 import Config from 'react-native-config'
@@ -62,13 +62,8 @@ import {
   getPhotosGeojson
 } from '../selectors'
 import BasemapModal from '../components/BasemapModal'
-import ActionButton from '../components/ActionButton'
 import Icon from '../components/Collecticons'
 import { colors } from '../style/variables'
-import { CameraButton } from '../components/CameraButton'
-import { RecordButton } from '../components/RecordButton'
-import { AddWayButton } from '../components/AddWayButton'
-import { AddPointButton } from '../components/AddPointButton'
 
 import icons from '../assets/icons'
 import { authorize } from '../services/auth'
@@ -106,6 +101,60 @@ const StyledMap = styled(MapboxGL.MapView)`
   width: 100%;
 `
 
+const MegaMenu = styled.View`
+  flex: 1;
+  position: absolute;
+  justify-content: center;
+  align-items: center;
+  bottom: 16;
+  right: 16;
+`
+
+const MenuButton = styled.TouchableHighlight`
+  border-radius: 100;
+  width: 56;
+  height: 56;
+  background-color: ${colors.primary};
+  justify-content: center;
+  align-items: center;
+  elevation: 2;
+  shadow-color: ${colors.base};
+  shadow-opacity: 0.7;
+  shadow-offset: 0px 0px;
+`
+
+const ModeButton = styled.TouchableHighlight`
+  position: absolute;
+  border-radius: 100;
+  bottom: -56;
+  right: -24;
+  width: 48;
+  height: 48;
+  margin-bottom: 8;
+  background-color: ${colors.primary};
+  justify-content: center;
+  align-items: center;
+  shadow-color: ${colors.baseAlpha};
+  shadow-opacity: 0.7;
+  shadow-offset: 0px 0px;
+  elevation: 2;
+`
+
+const Label = styled(Animated.Text)`
+  color: white;
+  position: absolute;
+  display: flex;
+  flex: 1;
+  right: 0;
+  bottom: -2;
+  text-align: right;
+  font-size: 14;
+  width: 100;
+  padding: 2px 4px;
+  border-radius: 4;
+  background-color: ${colors.baseMed};
+`
+
 class Explore extends React.Component {
   static navigationOptions = ({ navigation }) => {
     return {
@@ -125,10 +174,11 @@ class Explore extends React.Component {
     this.state = {
       androidPermissionGranted: false,
       isMapLoaded: false,
-      userTrackingMode: MapboxGL.UserTrackingModes.Follow,
-      addButtonExpanded: false
+      userTrackingMode: MapboxGL.UserTrackingModes.Follow
     }
   }
+
+  animation = new Animated.Value(0)
 
   shouldComponentUpdate (nextProps) {
     return nextProps.navigation.isFocused()
@@ -363,16 +413,18 @@ class Explore extends React.Component {
     )
   }
 
-  toggleAddButtonExpanded () {
-    const { addButtonExpanded } = this.state
+  toggleMenuOpen = () => {
+    const toValue = this.open ? 0 : 1
 
-    this.setState({
-      addButtonExpanded: !addButtonExpanded
-    })
+    Animated.spring(this.animation, {
+      toValue,
+      friction: 7
+    }).start()
+
+    this.open = !this.open
   }
 
   renderOverlay () {
-    const { addButtonExpanded } = this.state
     const { navigation, geojson, mode, currentTraceStatus } = this.props
 
     if (mode === modes.OFFLINE_TILES) {
@@ -390,8 +442,88 @@ class Explore extends React.Component {
       return null
     }
 
-    console.log('addButtonExpanded', addButtonExpanded)
     // if not in explicit mode, render default MapOverlay
+
+    const rotation = {
+      transform: [
+        {
+          rotate: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: ['0deg', '45deg']
+          })
+        }
+      ]
+    }
+
+    const opacityInterpolation = this.animation.interpolate({
+      inputRange: [0, 0.75, 1],
+      outputRange: [0, 0, 1]
+    })
+
+    const PointButtonPosition = {
+      opacity: opacityInterpolation,
+      transform: [
+        { scale: this.animation },
+        {
+          translateY: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -56]
+          })
+        }
+      ]
+    }
+
+    const WayButtonPosition = {
+      opacity: opacityInterpolation,
+      transform: [
+        { scale: this.animation },
+        {
+          translateY: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -112]
+          })
+        }
+      ]
+    }
+
+    const RecordButtonPosition = {
+      opacity: opacityInterpolation,
+      transform: [
+        { scale: this.animation },
+        {
+          translateY: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -168]
+          })
+        }
+      ]
+    }
+
+    const CameraButtonPosition = {
+      opacity: opacityInterpolation,
+      transform: [
+        { scale: this.animation },
+        {
+          translateY: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -224]
+          })
+        }
+      ]
+    }
+
+    const LabelPosition = {
+      opacity: opacityInterpolation,
+      transform: [
+        {
+          translateX: this.animation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -40]
+          })
+        }
+      ]
+    }
+
     return (
       <>
         <MapOverlay
@@ -399,15 +531,45 @@ class Explore extends React.Component {
           onAddButtonPress={this.onAddButtonPress}
           navigation={navigation}
         />
-        { addButtonExpanded && (
-          <>
-            <CameraButton onPress={() => navigation.navigate('CameraScreen', { previousScreen: 'Explore', feature: null })} />
-            <RecordButton status={currentTraceStatus} onPress={() => this.onRecordPress()} />
-            <AddWayButton onPress={() => { this.props.setMapMode(modes.ADD_WAY) }} />
-            <AddPointButton onPress={() => { this.onAddButtonPress() }} />
-          </>
-        )}
-        <ActionButton icon={addButtonExpanded ? 'xmark' : 'plus'} onPress={() => { this.toggleAddButtonExpanded() }} />
+        <MegaMenu>
+          <Animated.View style={[CameraButtonPosition]}>
+            <ModeButton underlayColor={colors.base} onPress={() => navigation.navigate('CameraScreen', { previousScreen: 'Explore', feature: null })}>
+              <View>
+                <Label style={[LabelPosition]}>Take Photo</Label>
+                <Icon name='camera' size={20} color='#FFFFFF' />
+              </View>
+            </ModeButton>
+          </Animated.View>
+          <Animated.View style={[RecordButtonPosition]}>
+            <ModeButton underlayColor={colors.base} status={currentTraceStatus} onPress={() => this.onRecordPress()}>
+              <View>
+                <Label style={[LabelPosition]}>Record Track</Label>
+                <Icon name='circle-play' size={20} color='#FFFFFF' />
+              </View>
+            </ModeButton>
+          </Animated.View>
+          <Animated.View style={[WayButtonPosition]}>
+            <ModeButton underlayColor={colors.base} onPress={() => { this.props.setMapMode(modes.ADD_WAY) }}>
+              <View>
+                <Label style={[LabelPosition]}>Add Way</Label>
+                <Icon name='share-2' size={20} color='#FFFFFF' />
+              </View>
+            </ModeButton>
+          </Animated.View>
+          <Animated.View style={[PointButtonPosition]}>
+            <ModeButton underlayColor={colors.base} onPress={() => { this.onAddButtonPress() }}>
+              <View>
+                <Label style={[LabelPosition]}>Add Point</Label>
+                <Icon name='marker' size={20} color='#FFFFFF' />
+              </View>
+            </ModeButton>
+          </Animated.View>
+          <MenuButton underlayColor={colors.base} onPress={this.toggleMenuOpen}>
+            <Animated.View style={[rotation]}>
+              <Icon name='plus' size={20} color='#FFFFFF' />
+            </Animated.View>
+          </MenuButton>
+        </MegaMenu>
       </>
     )
   }

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components/native'
-import { Platform, View, Animated } from 'react-native'
+import { Platform, TouchableHighlight, Animated } from 'react-native'
 import MapboxGL from '@react-native-mapbox-gl/maps'
 import { AndroidBackHandler } from 'react-navigation-backhandler'
 import Config from 'react-native-config'
@@ -122,12 +122,11 @@ const MenuButton = styled.TouchableHighlight`
   shadow-opacity: 0.7;
   shadow-offset: 0px 0px;
 `
+const AnimatedTouchable = Animated.createAnimatedComponent(TouchableHighlight)
 
-const ModeButton = styled.TouchableHighlight`
+const ModeButton = styled(AnimatedTouchable)`
   position: absolute;
   border-radius: 100;
-  bottom: -56;
-  right: -24;
   width: 48;
   height: 48;
   margin-bottom: 8;
@@ -143,10 +142,7 @@ const ModeButton = styled.TouchableHighlight`
 const Label = styled(Animated.Text)`
   color: white;
   position: absolute;
-  display: flex;
-  flex: 1;
   right: 0;
-  bottom: -2;
   text-align: right;
   font-size: 14;
   width: 100;
@@ -467,7 +463,7 @@ class Explore extends React.Component {
         {
           translateY: this.animation.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, -56]
+            outputRange: [0, -60]
           })
         }
       ]
@@ -480,7 +476,7 @@ class Explore extends React.Component {
         {
           translateY: this.animation.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, -112]
+            outputRange: [0, -116]
           })
         }
       ]
@@ -493,7 +489,7 @@ class Explore extends React.Component {
         {
           translateY: this.animation.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, -168]
+            outputRange: [0, -172]
           })
         }
       ]
@@ -506,7 +502,7 @@ class Explore extends React.Component {
         {
           translateY: this.animation.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, -224]
+            outputRange: [0, -228]
           })
         }
       ]
@@ -518,7 +514,7 @@ class Explore extends React.Component {
         {
           translateX: this.animation.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, -40]
+            outputRange: [0, -52]
           })
         }
       ]
@@ -532,38 +528,30 @@ class Explore extends React.Component {
           navigation={navigation}
         />
         <MegaMenu>
-          <Animated.View style={[CameraButtonPosition]}>
-            <ModeButton underlayColor={colors.base} onPress={() => navigation.navigate('CameraScreen', { previousScreen: 'Explore', feature: null })}>
-              <View>
-                <Label style={[LabelPosition]}>Take Photo</Label>
-                <Icon name='camera' size={20} color='#FFFFFF' />
-              </View>
-            </ModeButton>
-          </Animated.View>
-          <Animated.View style={[RecordButtonPosition]}>
-            <ModeButton underlayColor={colors.base} status={currentTraceStatus} onPress={() => this.onRecordPress()}>
-              <View>
-                <Label style={[LabelPosition]}>Record Track</Label>
-                <Icon name='circle-play' size={20} color='#FFFFFF' />
-              </View>
-            </ModeButton>
-          </Animated.View>
-          <Animated.View style={[WayButtonPosition]}>
-            <ModeButton underlayColor={colors.base} onPress={() => { this.props.setMapMode(modes.ADD_WAY) }}>
-              <View>
-                <Label style={[LabelPosition]}>Add Way</Label>
-                <Icon name='share-2' size={20} color='#FFFFFF' />
-              </View>
-            </ModeButton>
-          </Animated.View>
-          <Animated.View style={[PointButtonPosition]}>
-            <ModeButton underlayColor={colors.base} onPress={() => { this.onAddButtonPress() }}>
-              <View>
-                <Label style={[LabelPosition]}>Add Point</Label>
-                <Icon name='marker' size={20} color='#FFFFFF' />
-              </View>
-            </ModeButton>
-          </Animated.View>
+          <ModeButton style={[CameraButtonPosition]} underlayColor={colors.base} onPress={() => navigation.navigate('CameraScreen', { previousScreen: 'Explore', feature: null })}>
+            <>
+              <Label style={[LabelPosition]}>Take Photo</Label>
+              <Icon name='camera' size={20} color='#FFFFFF' />
+            </>
+          </ModeButton>
+          <ModeButton style={[RecordButtonPosition]} underlayColor={colors.base} status={currentTraceStatus} onPress={() => this.onRecordPress()}>
+            <>
+              <Label style={[LabelPosition]}>Record Track</Label>
+              <Icon name='circle-play' size={20} color='#FFFFFF' />
+            </>
+          </ModeButton>
+          <ModeButton style={[WayButtonPosition]} underlayColor={colors.base} onPress={() => { this.props.setMapMode(modes.ADD_WAY) }}>
+            <>
+              <Label style={[LabelPosition]}>Add Way</Label>
+              <Icon name='share-2' size={20} color='#FFFFFF' />
+            </>
+          </ModeButton>
+          <ModeButton style={[PointButtonPosition]} underlayColor={colors.base} onPress={() => { this.onAddButtonPress() }}>
+            <>
+              <Label style={[LabelPosition]}>Add Point</Label>
+              <Icon name='marker' size={20} color='#FFFFFF' />
+            </>
+          </ModeButton>
           <MenuButton underlayColor={colors.base} onPress={this.toggleMenuOpen}>
             <Animated.View style={[rotation]}>
               <Icon name='plus' size={20} color='#FFFFFF' />

--- a/app/screens/Features/AddFeatureDetail.js
+++ b/app/screens/Features/AddFeatureDetail.js
@@ -25,6 +25,7 @@ import TagEditor from '../../components/TagEditor'
 import { getParentPreset } from '../../utils/get-parent-preset'
 import { colors } from '../../style/variables'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import { modes } from '../../utils/map-modes'
 
 const FieldsList = styled.FlatList`
 `
@@ -154,7 +155,7 @@ class EditFeatureDetail extends React.Component {
 
     // call action to attempt to upload the edit
     this.props.uploadEdits([feature.id])
-    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: modes.EXPLORE })
   }
 
   isFeatureEmpty () {

--- a/app/screens/Features/EditFeatureDetail.js
+++ b/app/screens/Features/EditFeatureDetail.js
@@ -31,6 +31,7 @@ import { colors } from '../../style/variables'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { getPhotosForFeature } from '../../utils/photos'
 import PhotoGrid from '../../components/PhotoGrid'
+import { modes } from '../../utils/map-modes'
 
 const FieldsList = styled.FlatList`
 `
@@ -187,7 +188,7 @@ class EditFeatureDetail extends React.Component {
     this.props.editFeature(feature, newFeature, changesetComment)
     this.props.uploadEdits([feature.id])
 
-    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+    navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: modes.EXPLORE })
   }
 
   getNewFeature () {

--- a/app/screens/Features/ViewFeatureDetail.js
+++ b/app/screens/Features/ViewFeatureDetail.js
@@ -18,6 +18,7 @@ import { deleteFeature, uploadEdits } from '../../actions/edit'
 import { colors } from '../../style/variables'
 import PhotoGrid from '../../components/PhotoGrid'
 import { getPhotosForFeature } from '../../utils/photos'
+import { modes } from '../../utils/map-modes'
 
 const FieldsList = styled.SectionList`
 `
@@ -121,7 +122,7 @@ class ViewFeatureDetail extends React.Component {
 
       this.props.deleteFeature(feature, comment)
       this.props.uploadEdits([feature.id])
-      navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: 'explore' })
+      navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: modes.EXPLORE })
     }
 
     const headerActions = [

--- a/app/screens/OfflineMaps/OfflineAreaList.js
+++ b/app/screens/OfflineMaps/OfflineAreaList.js
@@ -56,7 +56,7 @@ class OfflineAreaList extends React.Component {
       // specify the screen to go back to when the back button is tapped
       back: 'OfflineAreaList',
       // tell the Explore screen what mode we're in
-      mode: modes.OFFLINE_MAPS,
+      mode: modes.OFFLINE_TILES,
       // provide a custom title for the Explore screen
       title: 'Download area',
       // provide some header actions for our use

--- a/app/screens/OfflineMaps/OfflineAreaList.js
+++ b/app/screens/OfflineMaps/OfflineAreaList.js
@@ -11,6 +11,7 @@ import { deleteOfflineResource, fetchOfflineResources } from '../../actions/map'
 import { setNotification } from '../../actions/notification'
 import { getOfflineResourceStatus, getVisibleBounds } from '../../selectors'
 import { getPlaceName } from '../../utils/get-place-name'
+import { modes } from '../../utils/map-modes'
 
 class OfflineAreaList extends React.Component {
   createOfflineResource = async () => {
@@ -55,7 +56,7 @@ class OfflineAreaList extends React.Component {
       // specify the screen to go back to when the back button is tapped
       back: 'OfflineAreaList',
       // tell the Explore screen what mode we're in
-      mode: 'bbox',
+      mode: modes.OFFLINE_MAPS,
       // provide a custom title for the Explore screen
       title: 'Download area',
       // provide some header actions for our use

--- a/app/utils/map-modes.js
+++ b/app/utils/map-modes.js
@@ -1,0 +1,17 @@
+export const modes = {
+  ADD_POINT: 'ADD_POINT',
+  EDIT_POINT: 'EDIT_POINT',
+  ADD_WAY: 'ADD_WAY',
+  EDIT_WAY: 'EDIT_WAY',
+  EXPLORE: 'EXPLORE',
+  OFFLINE_TILES: 'OFFLINE_TILES'
+}
+
+export const modeTitles = {
+  ADD_POINT: 'Add Point',
+  EDIT_POINT: 'Edit Point',
+  ADD_WAY: 'Add Way',
+  EDIT_WAY: 'Edit Way',
+  EXPLORE: 'Explore',
+  OFFLINE_TILES: 'Offline Maps'
+}


### PR DESCRIPTION
This adds a way editing mode to the explore screen. This added two new modes: one for adding ways, one for editing ways. It seemed like a good time to organize the mode switching somewhat to make it a little clearer. Primarily this meant implementing and using a `mapModes` object: https://github.com/developmentseed/observe/compare/way-editing-mode?expand=1#diff-151db68c781d309cbd0c2ffa7b9df353

Before merging this I need to fix the mode-related tests.

This pr really just focuses on implementing the new modes and a working button for entering the `Add Way` mode:

![Screen Shot 2020-02-10 at 3 30 30 PM](https://user-images.githubusercontent.com/164214/74199901-5066da80-4c1a-11ea-81ae-0092b8c747ee.png)
![Screen Shot 2020-02-10 at 3 30 38 PM](https://user-images.githubusercontent.com/164214/74199906-51980780-4c1a-11ea-95dc-a5e6b0cfccfa.png)

Immediate next steps that could happen in this pr or another:

- better managing the action buttons in the bottom right side of the screen based on `mode`
- more appropriate icon for the add way button
- implementing the flow of tapping the plus button, then choosing to tap the point, way, photo, or trace button