### PR TITLE
add babel-plugin-transform-remove-console

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,10 @@
 import React, { Component } from 'react'
+
+//if (process.env.NODE_ENV === 'development') {
+  const whyDidYouRender = require('@welldone-software/why-did-you-render');
+  whyDidYouRender(React);
+//}
+
 import Config from 'react-native-config'
 import { Provider } from 'react-redux'
 
@@ -36,6 +42,8 @@ import SaveTrace from './app/screens/SaveTrace'
 import { ReduxNetworkProvider } from 'react-native-offline'
 import Icon from './app/components/Collecticons'
 import { colors } from './app/style/variables'
+
+
 
 const OfflineMapsNavigator = createStackNavigator({
   OfflineAreaList: { screen: OfflineAreaList },

--- a/App.js
+++ b/App.js
@@ -45,8 +45,6 @@ import { ReduxNetworkProvider } from 'react-native-offline'
 import Icon from './app/components/Collecticons'
 import { colors } from './app/style/variables'
 
-
-
 const OfflineMapsNavigator = createStackNavigator({
   OfflineAreaList: { screen: OfflineAreaList },
   ViewOfflineAreaDetail: { screen: ViewOfflineAreaDetail }

--- a/App.js
+++ b/App.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 
-//if (process.env.NODE_ENV === 'development') {
-  const whyDidYouRender = require('@welldone-software/why-did-you-render');
-  whyDidYouRender(React);
-//}
+// NOTE: Comment out following lines to enable `why-did-you-render`
+
+// if (process.env.NODE_ENV === 'dev') {
+//   const whyDidYouRender = require('@welldone-software/why-did-you-render');
+//   whyDidYouRender(React);
+// }
 
 import Config from 'react-native-config'
 import { Provider } from 'react-redux'

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -8,6 +8,7 @@ import Config from 'react-native-config'
 import { NavigationEvents } from 'react-navigation'
 import _partition from 'lodash.partition'
 import _difference from 'lodash.difference'
+import _isEqual from'lodash.isequal'
 
 import {
   loadUserDetails
@@ -243,10 +244,17 @@ class Explore extends React.Component {
 
   async loadFeaturesAtPoint (rect) {
     try {
+      // console.time('query')
       const { features } = await this.mapRef.queryRenderedFeaturesInRect(rect, null, this.state.clickableLayers)
+      // console.timeEnd('query')
       const [ photos, osmFeatures ] = _partition(features, (f) => { return f.properties.type === 'photo' })
-      this.props.setSelectedFeatures(osmFeatures)
-      this.props.setSelectedPhotos(photos)
+      const { selectedPhotos, selectedFeatures } = this.props
+      if (!_isEqual(osmFeatures, selectedFeatures)) {
+        this.props.setSelectedFeatures(osmFeatures)
+      }
+      if (!_isEqual(photos, selectedPhotos)) {
+        this.props.setSelectedPhotos(photos)
+      }
     } catch (err) {
       console.log('failed getting features', err)
     }
@@ -598,7 +606,6 @@ class Explore extends React.Component {
                     onDidFinishRenderingMapFully={this.onDidFinishRenderingMapFully}
                     onWillStartLoadingMap={this.onWillStartLoadingMap}
                     onDidFailLoadingMap={this.onDidFailLoadingMap}
-                    onRegionIsChanging={this.onRegionIsChanging}
                     onRegionDidChange={this.onRegionDidChange}
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -7,6 +7,7 @@ import { AndroidBackHandler } from 'react-navigation-backhandler'
 import Config from 'react-native-config'
 import { NavigationEvents } from 'react-navigation'
 import _partition from 'lodash.partition'
+import _difference from 'lodash.difference'
 
 import {
   loadUserDetails
@@ -40,6 +41,7 @@ import {
   endTrace
 } from '../actions/traces'
 
+import { bboxToTiles } from '../utils/bbox'
 import Header from '../components/Header'
 import MapOverlay from '../components/MapOverlay'
 import AddPointOverlay from '../components/AddPointOverlay'
@@ -103,6 +105,9 @@ const StyledMap = styled(MapboxGL.MapView)`
 `
 
 class Explore extends React.Component {
+
+  static whyDidYouRender = true
+
   static navigationOptions = ({ navigation }) => {
     return {
       drawerLabel: 'Explore',
@@ -186,10 +191,10 @@ class Explore extends React.Component {
     console.log('onDidFailLoadingMap', err)
   }
 
-  onRegionIsChanging = async evt => {
-    // update the redux state with the bbox
-    this.props.updateVisibleBounds(await this.mapRef.getVisibleBounds(), await this.mapRef.getZoom())
-  }
+  // onRegionIsChanging = async evt => {
+  //   // update the redux state with the bbox
+  //   this.props.updateVisibleBounds(await this.mapRef.getVisibleBounds(), await this.mapRef.getZoom())
+  // }
 
   _fetchData (visibleBounds, zoomLevel) {
     // fetch new data only if zoom is greater than 16
@@ -200,6 +205,12 @@ class Explore extends React.Component {
 
   onRegionDidChange = evt => {
     const { properties: { visibleBounds, zoomLevel } } = evt
+    const oldBounds = this.props.visibleBounds
+    if (oldBounds && oldBounds.length) {
+      const oldTiles = bboxToTiles(oldBounds)
+      const currentTiles = bboxToTiles(visibleBounds)
+      if (_difference(oldTiles, currentTiles).length === 0) return
+    }
     this.props.updateVisibleBounds(visibleBounds, zoomLevel)
   }
 

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -8,7 +8,7 @@ import Config from 'react-native-config'
 import { NavigationEvents } from 'react-navigation'
 import _partition from 'lodash.partition'
 import _difference from 'lodash.difference'
-import _isEqual from'lodash.isequal'
+import _isEqual from 'lodash.isequal'
 
 import {
   loadUserDetails
@@ -106,7 +106,6 @@ const StyledMap = styled(MapboxGL.MapView)`
 `
 
 class Explore extends React.Component {
-
   static whyDidYouRender = true
 
   static navigationOptions = ({ navigation }) => {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset']
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['transform-remove-console']
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['transform-remove-console']
+  env: {
+    production: {
+      plugins: ['transform-remove-console']
+    }
+  }
 }

--- a/docs/apk.md
+++ b/docs/apk.md
@@ -1,9 +1,26 @@
-## To build a release APK
+# Creating a release APK
+
+## One-time setup:
 
 1. Get the keystore `observe.keystore` file from 1Password
 2. Drop this into `android/app`
 3. Get the `keystore.properties` file from 1Password
 4. Drop the `keystore.properties` file into `android/`
-5. Run `./gradlew clean && ./gradlew assemble`
 
-Look for debug and release APKs under `android/app/build/outputs`
+## Create the release:
+
+```
+cd android
+./gradlew clean
+./gradlew assemble
+```
+
+You'll find the release in this directory: `android/app/build/outputs/apk/release/`
+
+The APK can be installed on a device via the command line.
+
+From the `android/` directory:
+
+```bash
+adb install app/build/outputs/apk/release/{filename}.apk
+```

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@welldone-software/why-did-you-render": "^4.0.3",
     "babel-eslint": "^10.0.1",
     "babel-jest": "24.1.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "colors": "^1.3.3",
     "devseed-standard": "^1.1.0",
     "documentation": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.0",
     "@babel/runtime": "^7.5.0",
+    "@welldone-software/why-did-you-render": "^4.0.3",
     "babel-eslint": "^10.0.1",
     "babel-jest": "24.1.0",
     "colors": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,11 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz#c0e6347d3e0379ed84b3c2434d3467567aa05297"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,6 +1780,13 @@
     lodash "^4.5.0"
     prop-types "^15.6.1"
 
+"@welldone-software/why-did-you-render@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-4.0.3.tgz#f44804f1dbc6d9593ed0ade190185f72ca6d8077"
+  integrity sha512-B5whN0kIIsxorQEAD5sj7BHhULa3BlqGhgRtD6guT1MvsC9S7aN6vBVdFiTDapLhQ6OCUTcAzAcuhDrWnuKD6A==
+  dependencies:
+    lodash "^4"
+
 JSONStream@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.0.tgz#efc462d5a5bc94ec007f4b22571acd7f6f2ae013"
@@ -5913,7 +5920,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0, lodash@^4.6.1:
+lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
This branches from the perf/why-did-you-render branch and adds the babel plugin for removing console.* statements.

I also included some small docs improvements that adds to the docs/apk.md file to make it a little more clear / easy to see what to do. Sorry for the unrelated change.