### PR TITLE
Add "yarn/react-native start" to ios development instructions

### DIFF
--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -78,6 +78,7 @@ Follow the instructions under the tab "Building Projects with Native Code" for i
 ### Run the project in a simulator
 
 ```
+react-native start
 react-native run-ios
 ```
 


### PR DESCRIPTION
If this is commonly known and documented elsewhere, feel free to ignore this addition.