### PR TITLE
Nodecache eviction

### DIFF
--- a/__tests__/services/__snapshots__/nodecache.test.js.snap
+++ b/__tests__/services/__snapshots__/nodecache.test.js.snap
@@ -109,3 +109,17 @@ Object {
   },
 }
 `;
+
+exports[`remove nodes for a tile 1`] = `null`;
+
+exports[`remove nodes for a tile 2`] = `
+Object {
+  "node/8548730": null,
+  "node/8548853": null,
+  "node/8548854": null,
+  "node/8548856": null,
+  "node/8548857": null,
+  "node/8548858": null,
+  "node/8548859": null,
+}
+`;

--- a/__tests__/services/nodecache.test.js
+++ b/__tests__/services/nodecache.test.js
@@ -8,8 +8,8 @@ import {
   getNodes,
   getNodesForTile,
   getNodesForTiles,
-  clearCacheForTile,
-  purgeCache
+  clearNodeCacheForTile,
+  purgeNodeCache
 } from '../../app/services/nodecache'
 
 import nodes from '../fixtures/nodes.json'
@@ -42,7 +42,7 @@ test('get nodes for an array of tiles', async () => {
 })
 
 test('remove nodes for a tile', async () => {
-  await purgeCache()
+  await purgeNodeCache()
 
   const tile = '0320100322313212'
   const nodeIds = [ 'node/8548730',
@@ -54,7 +54,7 @@ test('remove nodes for a tile', async () => {
     'node/8548859' ]
   await addNodes(tile, nodes)
 
-  await clearCacheForTile(tile)
+  await clearNodeCacheForTile(tile)
   const dataForRemovedTile = await getNodesForTile(tile)
 
   const nodesFromCache = await getNodes(nodeIds)

--- a/__tests__/services/nodecache.test.js
+++ b/__tests__/services/nodecache.test.js
@@ -7,7 +7,9 @@ import {
   addNodes,
   getNodes,
   getNodesForTile,
-  getNodesForTiles
+  getNodesForTiles,
+  clearCacheForTile,
+  purgeCache
 } from '../../app/services/nodecache'
 
 import nodes from '../fixtures/nodes.json'
@@ -37,4 +39,25 @@ test('get nodes for an array of tiles', async () => {
 
   const tileNodes = await getNodesForTiles(tiles)
   expect(tileNodes).toMatchSnapshot()
+})
+
+test('remove nodes for a tile', async () => {
+  await purgeCache()
+
+  const tile = '0320100322313212'
+  const nodeIds = [ 'node/8548730',
+    'node/8548853',
+    'node/8548854',
+    'node/8548856',
+    'node/8548857',
+    'node/8548858',
+    'node/8548859' ]
+  await addNodes(tile, nodes)
+
+  await clearCacheForTile(tile)
+  const dataForRemovedTile = await getNodesForTile(tile)
+
+  const nodesFromCache = await getNodes(nodeIds)
+  expect(dataForRemovedTile).toMatchSnapshot()
+  expect(nodesFromCache).toMatchSnapshot()
 })

--- a/app/services/nodecache.js
+++ b/app/services/nodecache.js
@@ -61,7 +61,7 @@ export async function getNodesForTiles (tiles) {
 /**
  * Clear the async storage cache entirely
  */
-export async function purgeCache () {
+export async function purgeNodeCache () {
   try {
     await AsyncStorage.clear()
   } catch (error) {
@@ -73,7 +73,7 @@ export async function purgeCache () {
  * Remove nodes of a tile from the cache
  * @param {string} tile - tile id
  */
-export async function clearCacheForTile (tile) {
+export async function clearNodeCacheForTile (tile) {
   const keys = await getNodesForTile(tile)
   try {
     await AsyncStorage.multiRemove(keys)

--- a/app/services/nodecache.js
+++ b/app/services/nodecache.js
@@ -57,3 +57,28 @@ export async function getNodesForTiles (tiles) {
     return Promise.resolve({ ...newMemo })
   }, Promise.resolve({}))
 }
+
+/**
+ * Clear the async storage cache entirely
+ */
+export async function purgeCache () {
+  try {
+    await AsyncStorage.clear()
+  } catch (error) {
+    console.error('Failed to purge async storage cache')
+  }
+}
+
+/**
+ * Remove nodes of a tile from the cache
+ * @param {string} tile - tile id
+ */
+export async function clearCacheForTile (tile) {
+  const keys = await getNodesForTile(tile)
+  try {
+    await AsyncStorage.multiRemove(keys)
+    await AsyncStorage.removeItem(tile)
+  } catch (error) {
+    console.error('Failed to remove node', error)
+  }
+}


### PR DESCRIPTION
Fixes #171 
This PR:
* [x] add methods to purge nodecache and clear nodecache for a tile
* [x] purges the cache when all data is purged
* [x] evicts tile from nodecache when it's evicted from lru
* [x] evicts tile from nodecache when the data is stale / refreshed

