### PR TITLE
Move selected features member nodes to state

### DIFF
--- a/app/reducers/map.js
+++ b/app/reducers/map.js
@@ -11,6 +11,7 @@ export const initialState = {
   activeTileRequests: [], // quadkeys of all pending tile requests
   fetchedTiles: {}, // Object with mapping of tiles to their respective GeoJSON FeatureCollections
   selectedFeature: false, // GeoJSON feature that is currently selected, or false
+  selectedFeaturesMemberNodes: false,
   mode: modes.EXPLORE, // see app/utils/map-modes.js for all modes
   baseLayer: null,
   overlays: {
@@ -242,7 +243,8 @@ export default function (state = initialState, action) {
       features = _uniqBy(features, 'id')
       return {
         ...state,
-        selectedFeatures: features
+        selectedFeatures: features,
+        selectedFeaturesMemberNodes: features
       }
 
     case types.SET_SELECTED_WAY:
@@ -250,7 +252,8 @@ export default function (state = initialState, action) {
       console.log('# geojson', geojson)
       return {
         ...state,
-        nodes: geojson
+        nodes: geojson,
+        selectedFeaturesMemberNodes: geojson
       }
 
     case types.START_ADD_POINT:

--- a/app/reducers/map.js
+++ b/app/reducers/map.js
@@ -243,8 +243,7 @@ export default function (state = initialState, action) {
       features = _uniqBy(features, 'id')
       return {
         ...state,
-        selectedFeatures: features,
-        selectedFeaturesMemberNodes: features
+        selectedFeatures: features
       }
 
     case types.SET_SELECTED_WAY:

--- a/app/reducers/map.js
+++ b/app/reducers/map.js
@@ -252,7 +252,6 @@ export default function (state = initialState, action) {
       console.log('# geojson', geojson)
       return {
         ...state,
-        nodes: geojson,
         selectedFeaturesMemberNodes: geojson
       }
 

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -82,7 +82,7 @@ import { authorize } from '../services/auth'
 
 import { modes, modeTitles } from '../utils/map-modes'
 
-import { point as turfPoint } from '@turf/helpers'
+import { point as turfPoint, featureCollection } from '@turf/helpers'
 
 let osmStyleURL = Config.MAPBOX_STYLE_URL || MapboxGL.StyleURL.Street
 let satelliteStyleURL = Config.MAPBOX_SATELLITE_STYLE_URL || MapboxGL.StyleURL.Satellite
@@ -708,9 +708,8 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='currentWayEdit' shape={currentWayEdit}>
                       <MapboxGL.LineLayer id='currentWayLine' style={style.osm.editedLines} minZoomLevel={16} />
                     </MapboxGL.ShapeSource>
-                    <MapboxGL.ShapeSource id='selectedFeaturesMemberNodesSource' shape={selectedFeaturesMemberNodes || {}}>
+                    <MapboxGL.ShapeSource id='selectedFeaturesMemberNodesSource' shape={selectedFeaturesMemberNodes}>
                       <MapboxGL.CircleLayer id='selectedFeaturesMemberNodes' style={style.osm.nodes} minZoomLevel={16} />
-                      <MapboxGL.CircleLayer id='selectedFeaturesMemberNodesHalo' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.nodeHaloSelected} />
                     </MapboxGL.ShapeSource>
                     <MapboxGL.ShapeSource id='editingWayMemberNodesSource' shape={editingWayMemberNodes}>
                       <MapboxGL.CircleLayer id='editingWayMemberNodes' style={style.osm.nodes} minZoomLevel={16} />
@@ -777,7 +776,7 @@ const mapStateToProps = (state) => {
     currentTraceStatus: getCurrentTraceStatus(state),
     isConnected: state.network.isConnected,
     selectedFeatures: state.map.selectedFeatures || false,
-    selectedFeaturesMemberNodes: state.map.selectedFeaturesMemberNodes,
+    selectedFeaturesMemberNodes: state.map.selectedFeaturesMemberNodes || featureCollection([]),
     editingWayMemberNodes,
     mode: state.map.mode,
     edits: state.edit.edits,

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -457,6 +457,7 @@ class Explore extends React.Component {
       photosGeojson,
       selectedPhotos,
       selectedFeaturesMemberNodes,
+      editingWayMemberNodes,
       currentWayEdit,
       selectedNode,
       nearestFeatures
@@ -707,9 +708,13 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='currentWayEdit' shape={currentWayEdit}>
                       <MapboxGL.LineLayer id='currentWayLine' style={style.osm.editedLines} minZoomLevel={16} />
                     </MapboxGL.ShapeSource>
-                    <MapboxGL.ShapeSource id='nodesGeojsonSource' shape={selectedFeaturesMemberNodes || {}}>
-                      <MapboxGL.CircleLayer id='nodes' style={style.osm.nodes} minZoomLevel={16} />
-                      <MapboxGL.CircleLayer id='nodeHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.nodeHaloSelected} />
+                    <MapboxGL.ShapeSource id='selectedFeaturesMemberNodesSource' shape={selectedFeaturesMemberNodes || {}}>
+                      <MapboxGL.CircleLayer id='selectedFeaturesMemberNodes' style={style.osm.nodes} minZoomLevel={16} />
+                      <MapboxGL.CircleLayer id='selectedFeaturesMemberNodesHalo' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.nodeHaloSelected} />
+                    </MapboxGL.ShapeSource>
+                    <MapboxGL.ShapeSource id='editingWayMemberNodesSource' shape={editingWayMemberNodes}>
+                      <MapboxGL.CircleLayer id='editingWayMemberNodes' style={style.osm.nodes} minZoomLevel={16} />
+                      <MapboxGL.CircleLayer id='editingWayMemberNodesHalo' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.nodeHaloSelected} />
                     </MapboxGL.ShapeSource>
                     <MapboxGL.ShapeSource id='nearestFeatures' shape={nearestFeatures}>
                       <MapboxGL.CircleLayer id='nearestNodes' minZoomLevel={16} style={style.osm.nodes} />
@@ -740,7 +745,13 @@ const mapStateToProps = (state) => {
     features: []
   }
 
-  if (state.wayEditingHistory.present.way && state.wayEditingHistory.present.way.nodes && state.wayEditingHistory.present.way.nodes.length) {
+  let editingWayMemberNodes = {}
+
+  if (
+    state.wayEditingHistory.present.way &&
+    state.wayEditingHistory.present.way.nodes &&
+    state.wayEditingHistory.present.way.nodes.length
+  ) {
     currentWayEdit.features.push({
       type: 'Feature',
       geometry: {
@@ -750,6 +761,12 @@ const mapStateToProps = (state) => {
         })
       }
     })
+
+    editingWayMemberNodes = {
+      type: 'FeatureCollection',
+      properties: {},
+      features: state.wayEditingHistory.present.way.nodes
+    }
   }
 
   return {
@@ -761,6 +778,7 @@ const mapStateToProps = (state) => {
     isConnected: state.network.isConnected,
     selectedFeatures: state.map.selectedFeatures || false,
     selectedFeaturesMemberNodes: state.map.selectedFeaturesMemberNodes,
+    editingWayMemberNodes,
     mode: state.map.mode,
     edits: state.edit.edits,
     editsGeojson: state.edit.editsGeojson,

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -456,7 +456,7 @@ class Explore extends React.Component {
       style,
       photosGeojson,
       selectedPhotos,
-      nodesGeojson,
+      selectedFeaturesMemberNodes,
       currentWayEdit,
       selectedNode,
       nearestFeatures
@@ -707,7 +707,7 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='currentWayEdit' shape={currentWayEdit}>
                       <MapboxGL.LineLayer id='currentWayLine' style={style.osm.editedLines} minZoomLevel={16} />
                     </MapboxGL.ShapeSource>
-                    <MapboxGL.ShapeSource id='nodesGeojsonSource' shape={nodesGeojson}>
+                    <MapboxGL.ShapeSource id='nodesGeojsonSource' shape={selectedFeaturesMemberNodes || {}}>
                       <MapboxGL.CircleLayer id='nodes' style={style.osm.nodes} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='nodeHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.nodeHaloSelected} />
                     </MapboxGL.ShapeSource>
@@ -740,7 +740,6 @@ const mapStateToProps = (state) => {
     features: []
   }
 
-  let nodes
   if (state.wayEditingHistory.present.way && state.wayEditingHistory.present.way.nodes && state.wayEditingHistory.present.way.nodes.length) {
     currentWayEdit.features.push({
       type: 'Feature',
@@ -751,14 +750,6 @@ const mapStateToProps = (state) => {
         })
       }
     })
-
-    nodes = {
-      type: 'FeatureCollection',
-      properties: {},
-      features: state.wayEditingHistory.present.way.nodes
-    }
-  } else {
-    nodes = state.map.nodes
   }
 
   return {
@@ -769,6 +760,7 @@ const mapStateToProps = (state) => {
     currentTraceStatus: getCurrentTraceStatus(state),
     isConnected: state.network.isConnected,
     selectedFeatures: state.map.selectedFeatures || false,
+    selectedFeaturesMemberNodes: state.map.selectedFeaturesMemberNodes,
     mode: state.map.mode,
     edits: state.edit.edits,
     editsGeojson: state.edit.editsGeojson,
@@ -784,7 +776,6 @@ const mapStateToProps = (state) => {
     style: state.map.style,
     photosGeojson: getPhotosGeojson(state),
     selectedPhotos: state.map.selectedPhotos,
-    nodesGeojson: nodes,
     visibleTiles: getVisibleTiles(state),
     currentWayEdit,
     selectedNode: state.wayEditing.selectedNode,


### PR DESCRIPTION
This should fix "nodesGeojson is being hijacked by currentEditWay" issue. A state property was created to hold member nodes from selected features. It might help establishing a better pattern to implement moving nodes of existing ways.