### PR TITLE
Paint more features

### DIFF
--- a/app/reducers/map.js
+++ b/app/reducers/map.js
@@ -268,11 +268,21 @@ export default function (state = initialState, action) {
         mode: modes.EXPLORE
       }
 
-    case types.SET_MAP_MODE:
+    case types.SET_MAP_MODE: {
+      let updatedStyle = _cloneDeep(state.style)
+      if (action.mode === modes.ADD_WAY || action.mode === modes.EDIT_WAY) {
+        updatedStyle.osm.polygons.visibility = 'visible'
+        updatedStyle.osm.lines.visibility = 'visible'
+      } else {
+        updatedStyle.osm.polygons.visibility = 'none'
+        updatedStyle.osm.lines.visibility = 'none'
+      }
       return {
         ...state,
-        mode: action.mode
+        mode: action.mode,
+        style: updatedStyle
       }
+    }
 
     case types.UPDATE_VISIBLE_BOUNDS: {
       const { visibleBounds, zoom } = action

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -542,6 +542,12 @@ class Explore extends React.Component {
         ['has', 'amenity'],
         ['==', ['geometry-type'], 'Polygon']
       ],
+      water: [
+        'match',
+        ['get', 'natural'],
+        'water',
+        true, false
+      ],
       buildings: [
         'all',
         ['has', 'building'],
@@ -696,6 +702,7 @@ class Explore extends React.Component {
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='water' filter={filters.water} style={style.osm.water} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='selectedFeatures' filter={filters.selectedFeatures} style={style.osm.selectedFeatures.lines} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='iconHalo' style={style.osm.iconHalo} minZoomLevel={16} filter={filters.iconHalo} />
                       <MapboxGL.CircleLayer id='iconHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.iconHaloSelected} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -557,12 +557,6 @@ class Explore extends React.Component {
         ['has', 'amenity'],
         ['==', ['geometry-type'], 'Polygon']
       ],
-      water: [
-        'match',
-        ['get', 'natural'],
-        'water',
-        true, false
-      ],
       buildings: [
         'all',
         ['has', 'building'],
@@ -573,13 +567,7 @@ class Explore extends React.Component {
         [
           'match',
           ['get', 'leisure'],
-          ['pitch', 'track', 'garden', 'park'],
-          true, false
-        ],
-        [
-          'match',
-          ['get', 'natural'],
-          'wood',
+          ['pitch', 'track', 'garden', 'park', 'nature_reserve'],
           true, false
         ],
         [
@@ -588,6 +576,16 @@ class Explore extends React.Component {
           ['grass', 'forest', 'meadow'],
           true, false
         ]
+      ],
+      boundaries: [
+        'all',
+        ['has', 'boundary']
+      ],
+      natural: [
+        'match',
+        ['get', 'natural'],
+        ['wood', 'beach', 'water'],
+        true, false
       ],
       iconHalo: [
         'all',
@@ -714,6 +712,7 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='geojsonSource' shape={geojson}>
                       <MapboxGL.LineLayer id='roadsHighlight' filter={filters.allRoads} style={style.osm.lineHighlight} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='roads' filter={filters.allRoads} style={style.osm.highways} minZoomLevel={16} />
+                      <MapboxGL.LineLayer id='boundaries' filter={filters.boundaries} style={style.osm.boundaries} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
@@ -721,7 +720,7 @@ class Explore extends React.Component {
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='water' filter={filters.water} style={style.osm.water} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='natural' filter={filters.natural} style={style.osm.natural} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='selectedFeatures' filter={filters.selectedFeatures} style={style.osm.selectedFeatures.lines} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='iconHalo' style={style.osm.iconHalo} minZoomLevel={16} filter={filters.iconHalo} />
                       <MapboxGL.CircleLayer id='iconHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.iconHaloSelected} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -537,6 +537,11 @@ class Explore extends React.Component {
         ['has', 'waterway'],
         ['==', ['geometry-type'], 'LineString']
       ],
+      amenities: [
+        'all',
+        ['has', 'amenity'],
+        ['==', ['geometry-type'], 'Polygon']
+      ],
       buildings: [
         'all',
         ['has', 'building'],
@@ -689,6 +694,7 @@ class Explore extends React.Component {
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='selectedFeatures' filter={filters.selectedFeatures} style={style.osm.selectedFeatures.lines} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='iconHalo' style={style.osm.iconHalo} minZoomLevel={16} filter={filters.iconHalo} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -329,6 +329,7 @@ class Explore extends React.Component {
 
     if (mode === modes.ADD_WAY || mode === modes.EDIT_WAY) {
       this.props.resetWayEditing()
+      this.props.setMapMode(modes.EXPLORE)
     }
 
     this.props.mapBackPress()
@@ -733,18 +734,13 @@ class Explore extends React.Component {
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='natural' filter={filters.natural} style={style.osm.natural} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
+                      <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='selectedFeatures' filter={filters.selectedFeatures} style={style.osm.selectedFeatures.lines} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='iconHalo' style={style.osm.iconHalo} minZoomLevel={16} filter={filters.iconHalo} />
                       <MapboxGL.CircleLayer id='iconHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.iconHaloSelected} />
                       <MapboxGL.SymbolLayer id='pois' style={style.osm.icons} filter={filters.pois} />
                     </MapboxGL.ShapeSource>
-                    {
-                      (mode === modes.EDIT_WAY || mode === modes.ADD_WAY) &&
-                        <MapboxGL.ShapeSource id='geojsonSource' shape={geojson}>
-                          <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
-                          <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
-                        </MapboxGL.ShapeSource>
-                    }
                     <MapboxGL.ShapeSource id='editGeojsonSource' shape={editsGeojson}>
                       <MapboxGL.FillLayer id='editedPolygons' filter={filters.editedPolygons} style={style.osm.editedPolygons} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='editedIconHalo' style={style.osm.iconEditedHalo} minZoomLevel={16} filter={filters.editedPois} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -158,7 +158,7 @@ class Explore extends React.Component {
       isMapLoaded: true,
       clickableLayers: ['editedPois', 'pois', 'editedPolygons',
         'buildings', 'roads', 'roadsLower',
-        'railwayLine', 'waterLine', 'leisure', 'photos'],
+        'railwayLine', 'waterLine', 'leisure', 'photos', 'water', 'allPolygons', 'allLines'],
       userTrackingMode: MapboxGL.UserTrackingModes.None
     })
 
@@ -523,6 +523,15 @@ class Explore extends React.Component {
     }
 
     const filters = {
+      allPolygons: [
+        'any',
+        ['==', ['geometry-type'], 'Polygon'],
+        ['==', ['geometry-type'], 'MultiPolygon']
+      ],
+      allLines: [
+        'all',
+        ['==', ['geometry-type'], 'LineString']
+      ],
       allRoads: [
         'all',
         ['==', ['geometry-type'], 'LineString']
@@ -558,7 +567,7 @@ class Explore extends React.Component {
         [
           'match',
           ['get', 'leisure'],
-          ['pitch', 'track', 'garden'],
+          ['pitch', 'track', 'garden', 'park'],
           true, false
         ],
         [
@@ -570,7 +579,7 @@ class Explore extends React.Component {
         [
           'match',
           ['get', 'landuse'],
-          ['grass', 'forest'],
+          ['grass', 'forest', 'meadow'],
           true, false
         ]
       ],
@@ -699,8 +708,10 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='geojsonSource' shape={geojson}>
                       <MapboxGL.LineLayer id='roadsHighlight' filter={filters.allRoads} style={style.osm.lineHighlight} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='roads' filter={filters.allRoads} style={style.osm.highways} minZoomLevel={16} />
-                      <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} minZoomLevel={16} />
+                      <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
+                      <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -678,6 +678,8 @@ class Explore extends React.Component {
                     onRegionDidChange={this.onRegionDidChange}
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}
+                    compassViewPosition={1}
+                    compassViewMargins={[18, 6]}
                   >
                     <MapboxGL.Camera
                       zoomLevel={12}

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -158,7 +158,7 @@ class Explore extends React.Component {
       isMapLoaded: true,
       clickableLayers: ['editedPois', 'pois', 'editedPolygons',
         'buildings', 'roads', 'roadsLower',
-        'railwayLine', 'waterLine', 'leisure', 'photos', 'water', 'allPolygons', 'allLines'],
+        'railwayLine', 'waterLine', 'leisure', 'photos', 'natural', 'allPolygons', 'allLines'],
       userTrackingMode: MapboxGL.UserTrackingModes.None
     })
 

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -729,7 +729,6 @@ class Explore extends React.Component {
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
                       {/* <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} /> */}
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
@@ -739,6 +738,13 @@ class Explore extends React.Component {
                       <MapboxGL.CircleLayer id='iconHaloSelected' style={style.osm.iconHaloSelected} minZoomLevel={16} filter={filters.iconHaloSelected} />
                       <MapboxGL.SymbolLayer id='pois' style={style.osm.icons} filter={filters.pois} />
                     </MapboxGL.ShapeSource>
+                    {
+                      (mode === modes.EDIT_WAY || mode === modes.ADD_WAY) &&
+                        <MapboxGL.ShapeSource id='geojsonSource' shape={geojson}>
+                          <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
+                          <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
+                        </MapboxGL.ShapeSource>
+                    }
                     <MapboxGL.ShapeSource id='editGeojsonSource' shape={editsGeojson}>
                       <MapboxGL.FillLayer id='editedPolygons' filter={filters.editedPolygons} style={style.osm.editedPolygons} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='editedIconHalo' style={style.osm.iconEditedHalo} minZoomLevel={16} filter={filters.editedPois} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -524,13 +524,21 @@ class Explore extends React.Component {
 
     const filters = {
       allPolygons: [
-        'any',
-        ['==', ['geometry-type'], 'Polygon'],
-        ['==', ['geometry-type'], 'MultiPolygon']
+        'all',
+        ['!', ['has', 'building']],
+        ['!', ['has', 'amenity']],
+        [
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
+        ]
       ],
       allLines: [
         'all',
-        ['==', ['geometry-type'], 'LineString']
+        ['==', ['geometry-type'], 'LineString'],
+        ['!', ['has', 'waterway']],
+        ['!', ['has', 'railway']],
+        ['!', ['has', 'highway']]
       ],
       allRoads: [
         'all',
@@ -555,6 +563,7 @@ class Explore extends React.Component {
       amenities: [
         'all',
         ['has', 'amenity'],
+        ['!', ['has', 'building']],
         ['==', ['geometry-type'], 'Polygon']
       ],
       buildings: [
@@ -582,10 +591,14 @@ class Explore extends React.Component {
         ['has', 'boundary']
       ],
       natural: [
-        'match',
-        ['get', 'natural'],
-        ['wood', 'beach', 'water'],
-        true, false
+        'all',
+        ['==', ['geometry-type'], 'Polygon'],
+        [
+          'match',
+          ['get', 'natural'],
+          ['wood', 'beach', 'water'],
+          true, false
+        ]
       ],
       iconHalo: [
         'all',
@@ -691,8 +704,8 @@ class Explore extends React.Component {
                     onRegionDidChange={this.onRegionDidChange}
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}
-                    compassViewPosition={0}
-                    compassViewMargins={[16, 16]}
+                    // compassViewPosition={0}
+                    // compassViewMargins={[16, 16]}
                   >
                     <MapboxGL.Camera
                       zoomLevel={12}
@@ -712,9 +725,9 @@ class Explore extends React.Component {
                     <MapboxGL.ShapeSource id='geojsonSource' shape={geojson}>
                       <MapboxGL.LineLayer id='roadsHighlight' filter={filters.allRoads} style={style.osm.lineHighlight} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='roads' filter={filters.allRoads} style={style.osm.highways} minZoomLevel={16} />
-                      <MapboxGL.LineLayer id='boundaries' filter={filters.boundaries} style={style.osm.boundaries} minZoomLevel={16} />
+                      {/* <MapboxGL.LineLayer id='boundaries' filter={filters.boundaries} style={style.osm.boundaries} minZoomLevel={16} /> */}
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
-                      <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} />
+                      {/* <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} /> */}
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -546,6 +546,12 @@ class Explore extends React.Component {
         ['has', 'waterway'],
         ['==', ['geometry-type'], 'LineString']
       ],
+      coastlines: [
+        'match',
+        ['get', 'natural'],
+        'coastline',
+        true, false
+      ],
       amenities: [
         'all',
         ['has', 'amenity'],
@@ -687,8 +693,8 @@ class Explore extends React.Component {
                     onRegionDidChange={this.onRegionDidChange}
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}
-                    compassViewPosition={1}
-                    compassViewMargins={[18, 6]}
+                    compassViewPosition={0}
+                    compassViewMargins={[16, 16]}
                   >
                     <MapboxGL.Camera
                       zoomLevel={12}
@@ -709,7 +715,7 @@ class Explore extends React.Component {
                       <MapboxGL.LineLayer id='roadsHighlight' filter={filters.allRoads} style={style.osm.lineHighlight} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='roads' filter={filters.allRoads} style={style.osm.highways} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
-                      <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
+                      <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -22,6 +22,12 @@ const nodes = {
   circleOpacity: 0.6
 }
 
+const polygons = {
+  fillOpacity: 0.1,
+  fillColor: colors.baseMuted,
+  fillOutlineColor: colors.baseMuted
+}
+
 const lines = {
   lineWidth: thinLineWidth,
   lineColor: '#eaeaea'
@@ -95,6 +101,12 @@ const waterLine = {
   lineColor: '#7dd'
 }
 
+const coastline = {
+  lineWidth: thinLineWidth,
+  lineColor: '#4fa3fd',
+  lineDasharray: [0, 2, 2, 0]
+}
+
 const buildings = {
   fillColor: colors.base,
   fillOpacity: 0.2,
@@ -130,12 +142,6 @@ const leisure = {
 const water = {
   fillColor: 'rgba(30,160,250,0.3)',
   fillOutlineColor: 'blue'
-}
-
-const polygons = {
-  fillOpacity: 0.1,
-  fillColor: colors.baseMuted,
-  fillOutlineColor: colors.baseMuted
 }
 
 /*
@@ -285,6 +291,7 @@ export default {
     polygons,
     buildings,
     amenities,
+    coastline,
     water,
     leisure,
     iconHalo,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -25,12 +25,14 @@ const nodes = {
 const polygons = {
   fillOpacity: 0.1,
   fillColor: colors.baseMuted,
-  fillOutlineColor: colors.baseMuted
+  fillOutlineColor: colors.baseMuted,
+  visibility: 'none'
 }
 
 const lines = {
   lineWidth: thinLineWidth,
-  lineColor: '#eaeaea'
+  lineColor: '#eaeaea',
+  visibility: 'none'
 }
 
 const lineHighlight = {

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -154,7 +154,7 @@ const natural = {
     'beach', '#f0dd8a',
     '#a0ad5a'
   ],
-  fillOpacity: '0.3',
+  fillOpacity: 0.3,
   fillOutlineColor: '#0a42af'
 }
 

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -22,6 +22,11 @@ const nodes = {
   circleOpacity: 0.6
 }
 
+const lines = {
+  lineWidth: thinLineWidth,
+  lineColor: '#eaeaea'
+}
+
 const lineHighlight = {
   lineWidth: [
     'interpolate', ['linear'],
@@ -69,7 +74,7 @@ const highwaysLower = {
   lineWidth: thinLineWidth,
   lineDasharray: [2, 0, 0, 2],
   lineColor: [
-    'step',
+    'match',
     ['get', 'highway'],
     'foot', '#988',
     'footway', '#988',
@@ -97,9 +102,13 @@ const buildings = {
 }
 
 const amenities = {
-  fillColor: colors.primary,
-  fillOpacity: 0.2,
-  fillOutlineColor: colors.primary
+  fillColor: [
+    'match',
+    ['get', 'amenity'],
+    'parking', colors.muted,
+    'rgba(235, 225, 118, 0.3)'
+  ],
+  fillOutlineColor: colors.base
 }
 
 const editedPolygons = {
@@ -109,22 +118,24 @@ const editedPolygons = {
 }
 
 const leisure = {
-  fillColor: 'rgba(140, 208, 95, 0.3)',
+  fillColor: [
+    'match',
+    ['get', 'leisure'],
+    'pitch', '#dca',
+    'rgba(140, 208, 95, 0.3)'
+  ],
   fillOutlineColor: 'grey'
 }
 
 const water = {
-  fillColor: 'rgba(90,140,210,0.3)',
-  fillOutlineColor: 'grey'
+  fillColor: 'rgba(30,160,250,0.3)',
+  fillOutlineColor: 'blue'
 }
 
 const polygons = {
-  fillOpacity: 0.6,
-  fillColor: [
-    'step',
-    ['get', 'building'],
-    colors.secondary
-  ]
+  fillOpacity: 0.1,
+  fillColor: colors.baseMuted,
+  fillOutlineColor: colors.baseMuted
 }
 
 /*
@@ -134,7 +145,10 @@ const polygons = {
 const selectedNode = {
   circleRadius: 8,
   circleOpacity: 1,
-  circleColor: colors.primary
+  circleColor: colors.primary,
+  circleStrokeColor: colors.base,
+  circleStrokeWidth: 1,
+  circleStrokeOpacity: 0.5
 }
 
 const selectedLine = {
@@ -260,6 +274,7 @@ const photoIconSelected = {
 
 export default {
   osm: {
+    lines,
     nodes,
     highways,
     highwaysLower,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -53,6 +53,12 @@ const editedLines = {
   lineColor: colors.primary
 }
 
+const boundaries = {
+  lineWidth: thinLineWidth,
+  lineColor: '#985500',
+  lineDasharray: [0, 4, 4, 0]
+}
+
 const highways = {
   lineWidth: standardLineWidth,
   lineColor: [
@@ -125,7 +131,7 @@ const amenities = {
 
 const editedPolygons = {
   fillColor: colors.secondary,
-  fillOpacity: 0.4,
+  fillOpacity: 0.2,
   fillOutlineColor: colors.secondary
 }
 
@@ -139,9 +145,17 @@ const leisure = {
   fillOutlineColor: 'grey'
 }
 
-const water = {
-  fillColor: 'rgba(30,160,250,0.3)',
-  fillOutlineColor: 'blue'
+const natural = {
+  fillColor: [
+    'match',
+    ['get', 'natural'],
+    'water', 'rgb(50,130,220)',
+    'wood', 'rgb(110, 188, 75)',
+    'beach', '#f0dd8a',
+    '#a0ad5a'
+  ],
+  fillOpacity: '0.3',
+  fillOutlineColor: '#0a42af'
 }
 
 /*
@@ -149,12 +163,12 @@ const water = {
  */
 
 const selectedNode = {
-  circleRadius: 8,
+  circleRadius: 3,
   circleOpacity: 1,
-  circleColor: colors.primary,
-  circleStrokeColor: colors.base,
-  circleStrokeWidth: 1,
-  circleStrokeOpacity: 0.5
+  circleColor: 'white',
+  circleStrokeColor: colors.primary,
+  circleStrokeWidth: 2,
+  circleStrokeOpacity: 1
 }
 
 const selectedLine = {
@@ -169,8 +183,8 @@ const selectedLine = {
 
 const editingNodes = {
   circleColor: colors.secondary,
-  circleRadius: 8,
-  circleOpacity: 0.9,
+  circleRadius: 4,
+  circleOpacity: 1,
   circleStrokeColor: 'white',
   circleStrokeWidth: 2,
   circleStrokeOpacity: 0.5
@@ -182,8 +196,8 @@ const editingLines = {
 }
 
 const nearestNodes = {
-  circleColor: colors.secondary,
-  circleRadius: 6,
+  circleColor: 'white',
+  circleRadius: 3,
   circleOpacity: 0.5,
   circleStrokeColor: colors.base,
   circleStrokeWidth: 2,
@@ -217,10 +231,10 @@ const iconEditedHalo = {
 }
 
 const iconHaloSelected = {
-  circleRadius: 15,
+  circleRadius: 12,
   circleColor: colors.primary,
   circleOpacity: 0.6,
-  circleStrokeColor: colors.base,
+  circleStrokeColor: 'white',
   circleStrokeWidth: 2,
   circleStrokeOpacity: 0.6
 }
@@ -282,6 +296,7 @@ export default {
   osm: {
     lines,
     nodes,
+    boundaries,
     highways,
     highwaysLower,
     railwayLine,
@@ -292,7 +307,7 @@ export default {
     buildings,
     amenities,
     coastline,
-    water,
+    natural,
     leisure,
     iconHalo,
     iconHaloSelected,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -96,10 +96,16 @@ const buildings = {
   fillOutlineColor: colors.base
 }
 
-const editedPolygons = {
+const amenities = {
   fillColor: colors.primary,
   fillOpacity: 0.2,
   fillOutlineColor: colors.primary
+}
+
+const editedPolygons = {
+  fillColor: colors.secondary,
+  fillOpacity: 0.4,
+  fillOutlineColor: colors.secondary
 }
 
 const leisure = {
@@ -258,6 +264,7 @@ export default {
     selectedLine,
     polygons,
     buildings,
+    amenities,
     leisure,
     iconHalo,
     iconHaloSelected,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -113,6 +113,11 @@ const leisure = {
   fillOutlineColor: 'grey'
 }
 
+const water = {
+  fillColor: 'rgba(90,140,210,0.3)',
+  fillOutlineColor: 'grey'
+}
+
 const polygons = {
   fillOpacity: 0.6,
   fillColor: [
@@ -265,6 +270,7 @@ export default {
     polygons,
     buildings,
     amenities,
+    water,
     leisure,
     iconHalo,
     iconHaloSelected,


### PR DESCRIPTION
~PR to add more features to draw in app. First test feature is `tag = amenity`, though I'm unsure whether this is called correctly in the `filters`. The amenities rendered are also not yet clickable.~

~@developmentseed/observe I'd love to know more about how to set up the filters correctly, and if there are other specific features we should be adding. Amenities seems to capture quite a lot of the missing tags, though the only way I'm verifying this is by browsing an area in Observe and OpenStreetMap at the same time.~

In screenshot below, the light primary purple color represents `amenity = parking lot`, while the secondary red color is an edited polygon.

![image](https://user-images.githubusercontent.com/12634024/82485676-cb595000-9aa9-11ea-9aa5-97d6e37c3833.png)
