### PR TITLE
Fix map overlay list

### DIFF
--- a/app/components/MapOverlay.js
+++ b/app/components/MapOverlay.js
@@ -77,23 +77,19 @@ const Grabber = styled.View`
 class MapOverlay extends Component {
   renderFeature (feature) {
     const { navigation } = this.props
-    function onPress () {
-      navigation.navigate('ViewFeatureDetail', { feature })
-    }
 
-    const name = feature.properties.name || feature.properties['name:end'] || feature.properties.brand || undefined
-    let nameText
-    if (name) {
-      nameText = (
-        <NameText>{feature.properties.hasOwnProperty('name') ? feature.properties.name : ''}</NameText>
-      )
-    }
+    const name =
+      feature.properties.name ||
+      feature.properties['name:end'] ||
+      feature.properties.brand
 
     return (
-      <Feature onPress={onPress}>
+      <Feature
+        onPress={() => navigation.navigate('ViewFeatureDetail', { feature })}
+      >
         <FeatureText>
-          {nameText}
-          <BoldText>{ getTaginfo(feature) }</BoldText>
+          {name && <NameText>{name}</NameText>}
+          <BoldText>{getTaginfo(feature)}</BoldText>
           <Text>{feature.id}</Text>
         </FeatureText>
       </Feature>

--- a/app/components/MapOverlay.js
+++ b/app/components/MapOverlay.js
@@ -129,7 +129,7 @@ class MapOverlay extends Component {
   render () {
     const { features, selectedFeatures, selectedPhotos } = this.props
     if ((selectedFeatures && selectedFeatures.length > 0) || (selectedPhotos && selectedPhotos.length > 0)) {
-      const featureSection = { 'title': 'Featues', 'data': selectedFeatures || features }
+      const featureSection = { 'title': 'Features', 'data': selectedFeatures || features }
       const photoSection = { 'title': 'Photos', 'data': selectedPhotos }
 
       return (

--- a/app/components/MapOverlay.js
+++ b/app/components/MapOverlay.js
@@ -145,7 +145,7 @@ class MapOverlay extends Component {
               <ItemList
                 sections={[featureSection, photoSection]}
                 renderItem={({ item }) => { return this.renderItem(item) }}
-                keyExtractor={(item, i) => `${item.properties.id}`}
+                keyExtractor={(item, i) => item.properties.id + i}
               />
             </FeatureListWrapper>
           </Drawer>


### PR DESCRIPTION
This affects #241 and #188. The fix was made by using the index to set property `keyExtractor` in order to generate unique ids for items in the list. I also did a refactor on renderFeature(), not related to the problem, but needed to improve readability.