### PR TITLE
Add natural, leisure and landuse styles

### DIFF
--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -160,7 +160,7 @@ class Explore extends React.Component {
       isMapLoaded: true,
       clickableLayers: ['editedPois', 'pois', 'editedPolygons',
         'buildings', 'roads', 'roadsLower',
-        'railwayLine', 'waterLine', 'waterFill', 'leisure', 'photos', 'natural', 'allPolygons', 'allLines'],
+        'railwayLine', 'waterLine', 'waterFill', 'leisure', 'landuse', 'photos', 'natural', 'allPolygons', 'allLines'],
       userTrackingMode: MapboxGL.UserTrackingModes.None
     })
 
@@ -603,8 +603,11 @@ class Explore extends React.Component {
         'all',
         ['has', 'amenity'],
         ['!', ['has', 'building']],
-        ['==', ['geometry-type'], 'Polygon'],
-        ['==', ['geometry-type'], 'MultiPolygon']
+        [
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
+        ]
       ],
       buildings: [
         'all',
@@ -612,18 +615,21 @@ class Explore extends React.Component {
         filteredFeatureIds && filteredFeatureIds.ways[2].length ? filteredFeatureIds.ways : ['match', ['get', 'id'], [''], false, true]
       ],
       leisure: [
-        'any',
+        'all',
+        ['has', 'leisure'],
         [
-          'match',
-          ['get', 'leisure'],
-          ['pitch', 'track', 'garden', 'park', 'nature_reserve'],
-          true, false
-        ],
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
+        ]
+      ],
+      landuse: [
+        'all',
+        ['has', 'landuse'],
         [
-          'match',
-          ['get', 'landuse'],
-          ['grass', 'forest', 'meadow'],
-          true, false
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
         ]
       ],
       boundaries: [
@@ -632,13 +638,11 @@ class Explore extends React.Component {
       ],
       natural: [
         'all',
-        ['==', ['geometry-type'], 'Polygon'],
-        ['==', ['geometry-type'], 'MultiPolygon'],
+        ['has', 'natural'],
         [
-          'match',
-          ['get', 'natural'],
-          ['wood', 'beach', 'water'],
-          true, false
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
         ]
       ],
       iconHalo: [
@@ -771,11 +775,12 @@ class Explore extends React.Component {
                       {/* <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} /> */}
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='waterFill' filter={filters.waterFill} style={style.osm.waterFill} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='natural' filter={filters.natural} style={style.osm.natural} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='landuse' filter={filters.landuse} style={style.osm.landuse} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='allLines' filter={filters.allLines} style={style.osm.lines} minZoomLevel={16} />
                       <MapboxGL.LineLayer id='selectedFeatures' filter={filters.selectedFeatures} style={style.osm.selectedFeatures.lines} minZoomLevel={16} />
                       <MapboxGL.CircleLayer id='iconHalo' style={style.osm.iconHalo} minZoomLevel={16} filter={filters.iconHalo} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -592,7 +592,8 @@ class Explore extends React.Component {
         'all',
         ['has', 'amenity'],
         ['!', ['has', 'building']],
-        ['==', ['geometry-type'], 'Polygon']
+        ['==', ['geometry-type'], 'Polygon'],
+        ['==', ['geometry-type'], 'MultiPolygon']
       ],
       buildings: [
         'all',
@@ -621,6 +622,7 @@ class Explore extends React.Component {
       natural: [
         'all',
         ['==', ['geometry-type'], 'Polygon'],
+        ['==', ['geometry-type'], 'MultiPolygon'],
         [
           'match',
           ['get', 'natural'],

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -160,7 +160,7 @@ class Explore extends React.Component {
       isMapLoaded: true,
       clickableLayers: ['editedPois', 'pois', 'editedPolygons',
         'buildings', 'roads', 'roadsLower',
-        'railwayLine', 'waterLine', 'leisure', 'photos', 'natural', 'allPolygons', 'allLines'],
+        'railwayLine', 'waterLine', 'waterFill', 'leisure', 'photos', 'natural', 'allPolygons', 'allLines'],
       userTrackingMode: MapboxGL.UserTrackingModes.None
     })
 
@@ -582,6 +582,17 @@ class Explore extends React.Component {
         ['has', 'waterway'],
         ['==', ['geometry-type'], 'LineString']
       ],
+      waterFill: [
+        'all',
+        ['has', 'waterway'],
+        ['!', ['has', 'building']],
+        ['!', ['has', 'amenity']],
+        [
+          'any',
+          ['==', ['geometry-type'], 'Polygon'],
+          ['==', ['geometry-type'], 'MultiPolygon']
+        ]
+      ],
       coastlines: [
         'match',
         ['get', 'natural'],
@@ -759,6 +770,7 @@ class Explore extends React.Component {
                       <MapboxGL.LineLayer id='railwayLine' filter={filters.railwayLine} style={style.osm.railwayLine} minZoomLevel={16} />
                       {/* <MapboxGL.LineLayer id='coastlines' filter={filters.coastlines} style={style.osm.coastline} minZoomLevel={16} /> */}
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='waterFill' filter={filters.waterFill} style={style.osm.waterFill} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='buildings' filter={filters.buildings} style={style.osm.buildings} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -143,6 +143,7 @@ const amenities = {
     'parking', colors.muted,
     'rgba(235, 225, 118, 0.3)'
   ],
+  fillOpacity: 0.3,
   fillOutlineColor: colors.base
 }
 
@@ -157,6 +158,8 @@ const leisure = {
     'match',
     ['get', 'leisure'],
     'pitch', '#dca',
+    'track', '#a93a28',
+    'swimming_pool', '#0ef',
     '#3fbd30'
   ],
   fillOpacity: 0.3,
@@ -167,13 +170,45 @@ const natural = {
   fillColor: [
     'match',
     ['get', 'natural'],
+    'wetland', '#0a42af',
     'water', 'rgb(50,130,220)',
-    'wood', 'rgb(110, 188, 75)',
+    'bay', '#4fa3fd',
+    'glacier', '#7a9af0',
+    'wood', '#3aaf3a',
+    'scrub', 'rgb(110, 188, 75)',
     'beach', '#f0dd8a',
-    '#a0ad5a'
+    'sand', '#f0dd8a',
+    'cliff', '#434343',
+    'rock', '#677587',
+    'scree', '#679587',
+    'stone', '#574557',
+    'shingle', '#777577',
+    'bare_rock', '#f7f5f7',
+    'cave_entrance', '#677587',
+    '#aDeB50'
   ],
   fillOpacity: 0.3,
   fillOutlineColor: '#0a42af'
+}
+
+const landuse = {
+  fillColor: [
+    'match',
+    ['get', 'landuse'],
+    'meadow', '#CDEBB0',
+    'residential', 'rgb(196, 189, 25)',
+    'retail', 'rgb(214, 136, 26)',
+    'commericial', 'rgb(214, 136, 26)',
+    'military', 'rgb(214, 136, 26)',
+    'landfill', 'rgb(214, 136, 26)',
+    'industrial', 'rgb(228, 164, 245)',
+    'railway', 'rgb(140, 140, 140)',
+    'quarry', 'rgb(140, 140, 140)',
+    'farmyard', 'rgb(245, 220, 186)',
+    '#3fbd30'
+  ],
+  fillOpacity: 0.3,
+  fillOutlineColor: '#1da01a'
 }
 
 /*
@@ -327,6 +362,7 @@ export default {
     amenities,
     coastline,
     natural,
+    landuse,
     leisure,
     iconHalo,
     iconHaloSelected,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -181,7 +181,7 @@ const natural = {
  */
 
 const selectedNode = {
-  circleRadius: 3,
+  circleRadius: 6,
   circleOpacity: 1,
   circleColor: 'white',
   circleStrokeColor: colors.primary,
@@ -215,7 +215,7 @@ const editingLines = {
 
 const nearestNodes = {
   circleColor: 'white',
-  circleRadius: 3,
+  circleRadius: 4,
   circleOpacity: 0.5,
   circleStrokeColor: colors.base,
   circleStrokeWidth: 2,
@@ -252,8 +252,8 @@ const iconHaloSelected = {
   circleRadius: 12,
   circleColor: colors.primary,
   circleOpacity: 0.6,
-  circleStrokeColor: 'white',
-  circleStrokeWidth: 2,
+  circleStrokeColor: colors.primary,
+  circleStrokeWidth: 4,
   circleStrokeOpacity: 0.6
 }
 

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -109,6 +109,21 @@ const waterLine = {
   lineColor: '#7dd'
 }
 
+const waterFill = {
+  fillColor: [
+    'match',
+    ['get', 'waterway'],
+    'boatyard', '#30778b',
+    'dam', '#677587',
+    'fuel', '#4f4536',
+    'dock', '#1e4d87',
+    'riverbank', '#413b7e',
+    '#0aa9da'
+  ],
+  fillOpacity: 0.3,
+  fillOutlineColor: '#0f33a9'
+}
+
 const coastline = {
   lineWidth: thinLineWidth,
   lineColor: '#4fa3fd',
@@ -142,9 +157,10 @@ const leisure = {
     'match',
     ['get', 'leisure'],
     'pitch', '#dca',
-    'rgba(140, 208, 95, 0.3)'
+    '#3fbd30'
   ],
-  fillOutlineColor: 'grey'
+  fillOpacity: 0.3,
+  fillOutlineColor: '#6fd02a'
 }
 
 const natural = {
@@ -303,6 +319,7 @@ export default {
     highwaysLower,
     railwayLine,
     waterLine,
+    waterFill,
     lineHighlight,
     selectedLine,
     polygons,


### PR DESCRIPTION
This PR:
- Adds multiple styles for landuse, leisure and natural.
- Re-defines filters for leisure and. natural to include all objects with these tags. 
- Attempts to reorder layers for rendering priority
- Closes #250 

Seen below, Central Park NYC (with Mapbox Light as baselayer). Note that the water, building, and other layers are under the man park layer. Attempted reordering this in multiple ways, but am not sure how we can resolve this. It would also be an improvement to be able to tap smaller features like buildings within larger areas with more accuracy.
<img width="440" alt="Screen Shot 2020-05-26 at 12 52 29 PM" src="https://user-images.githubusercontent.com/12634024/82930494-7dce5e80-9f53-11ea-836d-e75a2b44e7c3.png">
