### PR TITLE
Set style of Way Editing Overlay on edit/selection

### DIFF
--- a/app/components/WayEditingOverlay.js
+++ b/app/components/WayEditingOverlay.js
@@ -78,6 +78,11 @@ const ActionButton = styled(AnimatedTouchable)`
   justify-content: center;
   align-items: center;
   border-radius: 100;
+  ${({ disabled }) => disabled && `    
+    background: red;
+    shadow-color: ${colors.primary};
+  `}
+
 `
 
 const CompleteWayButton = styled.TouchableHighlight`
@@ -247,6 +252,12 @@ class WayEditingOverlay extends React.Component {
   }
 
   render () {
+    const { wayEditing, wayEditingHistory } = this.props
+
+    const canDeleteOrMove = wayEditing.selectedNode
+    const hasPast = wayEditingHistory.past.length > 0
+    const hasFuture = wayEditingHistory.future.length > 0
+
     return (
       <Container pointerEvents={Platform.OS === 'ios' ? 'box-none' : 'auto'}>
         <CrossHairOverlay />
@@ -256,19 +267,19 @@ class WayEditingOverlay extends React.Component {
         </CompleteWayButton>
 
         <MenuWrapper>
-          <ActionButton onPress={() => this.onDeleteNodePress()} underlayColor='#E4E6F2'>
+          <ActionButton disabled={!canDeleteOrMove} onPress={() => canDeleteOrMove && this.onDeleteNodePress()} underlayColor='#E4E6F2'>
             <Icon name='trash-bin' size={24} color={colors.primary} />
           </ActionButton>
-          <ActionButton onPress={() => this.onUndoPress()} underlayColor='#E4E6F2'>
+          <ActionButton disabled={!hasPast} onPress={() => this.onUndoPress()} underlayColor='#E4E6F2'>
             <Icon name='arrow-semi-spin-ccw' size={24} color={colors.primary} />
           </ActionButton>
           <AddNodeButton onPress={() => this.onAddNodePress()} underlayColor='#E4E6F2'>
             <Icon name='plus' size={24} color={colors.primary} />
           </AddNodeButton>
-          <ActionButton onPress={() => this.onRedoPress()} underlayColor='#E4E6F2'>
+          <ActionButton disabled={!hasFuture} onPress={() => this.onRedoPress()} underlayColor='#E4E6F2'>
             <Icon name='arrow-semi-spin-cw' size={24} color={colors.primary} />
           </ActionButton>
-          <ActionButton onPress={() => this.onMoveNodePress()} underlayColor='#E4E6F2'>
+          <ActionButton disabled={!canDeleteOrMove} onPress={() => canDeleteOrMove && this.onMoveNodePress()} underlayColor='#E4E6F2'>
             <Icon name='arrow-move' size={24} color={colors.primary} />
           </ActionButton>
         </MenuWrapper>

--- a/app/components/WayEditingOverlay.js
+++ b/app/components/WayEditingOverlay.js
@@ -78,11 +78,10 @@ const ActionButton = styled(AnimatedTouchable)`
   justify-content: center;
   align-items: center;
   border-radius: 100;
-  ${({ disabled }) => disabled && `    
-    background: red;
-    shadow-color: ${colors.primary};
-  `}
+`
 
+const ActionButtonIcon = styled(Icon)`
+  color: ${({ disabled }) => !disabled ? colors.primary : colors.muted}
 `
 
 const CompleteWayButton = styled.TouchableHighlight`
@@ -267,20 +266,20 @@ class WayEditingOverlay extends React.Component {
         </CompleteWayButton>
 
         <MenuWrapper>
-          <ActionButton disabled={!canDeleteOrMove} onPress={() => canDeleteOrMove && this.onDeleteNodePress()} underlayColor='#E4E6F2'>
-            <Icon name='trash-bin' size={24} color={colors.primary} />
+          <ActionButton onPress={() => canDeleteOrMove && this.onDeleteNodePress()} underlayColor='#E4E6F2'>
+            <ActionButtonIcon name='trash-bin' size={24} disabled={!canDeleteOrMove} />
           </ActionButton>
-          <ActionButton disabled={!hasPast} onPress={() => this.onUndoPress()} underlayColor='#E4E6F2'>
-            <Icon name='arrow-semi-spin-ccw' size={24} color={colors.primary} />
+          <ActionButton onPress={() => this.onUndoPress()} underlayColor='#E4E6F2'>
+            <ActionButtonIcon name='arrow-semi-spin-ccw' size={24} disabled={!hasPast} />
           </ActionButton>
           <AddNodeButton onPress={() => this.onAddNodePress()} underlayColor='#E4E6F2'>
             <Icon name='plus' size={24} color={colors.primary} />
           </AddNodeButton>
-          <ActionButton disabled={!hasFuture} onPress={() => this.onRedoPress()} underlayColor='#E4E6F2'>
-            <Icon name='arrow-semi-spin-cw' size={24} color={colors.primary} />
+          <ActionButton onPress={() => this.onRedoPress()} underlayColor='#E4E6F2'>
+            <ActionButtonIcon name='arrow-semi-spin-cw' size={24} disabled={!hasFuture} />
           </ActionButton>
-          <ActionButton disabled={!canDeleteOrMove} onPress={() => canDeleteOrMove && this.onMoveNodePress()} underlayColor='#E4E6F2'>
-            <Icon name='arrow-move' size={24} color={colors.primary} />
+          <ActionButton onPress={() => canDeleteOrMove && this.onMoveNodePress()} underlayColor='#E4E6F2'>
+            <ActionButtonIcon name='arrow-move' size={24} disabled={!canDeleteOrMove} />
           </ActionButton>
         </MenuWrapper>
         <FeatureRelationErrorDialog

--- a/app/components/WayEditingOverlay.js
+++ b/app/components/WayEditingOverlay.js
@@ -266,20 +266,51 @@ class WayEditingOverlay extends React.Component {
         </CompleteWayButton>
 
         <MenuWrapper>
-          <ActionButton onPress={() => canDeleteOrMove && this.onDeleteNodePress()} underlayColor='#E4E6F2'>
-            <ActionButtonIcon name='trash-bin' size={24} disabled={!canDeleteOrMove} />
+          <ActionButton
+            onPress={() => canDeleteOrMove && this.onDeleteNodePress()}
+            underlayColor='#E4E6F2'
+          >
+            <ActionButtonIcon
+              name='trash-bin'
+              size={24}
+              disabled={!canDeleteOrMove}
+            />
           </ActionButton>
-          <ActionButton onPress={() => this.onUndoPress()} underlayColor='#E4E6F2'>
-            <ActionButtonIcon name='arrow-semi-spin-ccw' size={24} disabled={!hasPast} />
+          <ActionButton
+            onPress={() => hasPast && this.onUndoPress()}
+            underlayColor='#E4E6F2'
+          >
+            <ActionButtonIcon
+              name='arrow-semi-spin-ccw'
+              size={24}
+              disabled={!hasPast}
+            />
           </ActionButton>
-          <AddNodeButton onPress={() => this.onAddNodePress()} underlayColor='#E4E6F2'>
+          <AddNodeButton
+            onPress={() => this.onAddNodePress()}
+            underlayColor='#E4E6F2'
+          >
             <Icon name='plus' size={24} color={colors.primary} />
           </AddNodeButton>
-          <ActionButton onPress={() => this.onRedoPress()} underlayColor='#E4E6F2'>
-            <ActionButtonIcon name='arrow-semi-spin-cw' size={24} disabled={!hasFuture} />
+          <ActionButton
+            onPress={() => hasFuture && this.onRedoPress()}
+            underlayColor='#E4E6F2'
+          >
+            <ActionButtonIcon
+              name='arrow-semi-spin-cw'
+              size={24}
+              disabled={!hasFuture}
+            />
           </ActionButton>
-          <ActionButton onPress={() => canDeleteOrMove && this.onMoveNodePress()} underlayColor='#E4E6F2'>
-            <ActionButtonIcon name='arrow-move' size={24} disabled={!canDeleteOrMove} />
+          <ActionButton
+            onPress={() => canDeleteOrMove && this.onMoveNodePress()}
+            underlayColor='#E4E6F2'
+          >
+            <ActionButtonIcon
+              name='arrow-move'
+              size={24}
+              disabled={!canDeleteOrMove}
+            />
           </ActionButton>
         </MenuWrapper>
         <FeatureRelationErrorDialog


### PR DESCRIPTION
Work in progress to address #234. At the moment a simple style was applied to the TouchableHighlight on changes in edit/select state. Issues:

- `wayEditingHistory.past` seems to be initiated with a "blank" command. When the screen is opened, the button is active but no command was performed yet
- Neither Icon or ActionButton have "disabled" property. Should we change them to a Button or apply a "disabled" style? At the moment a style was applied to `ActionButton`, I believe it makes more sense to apply it to the Icon if we don't change to Button

cc @geohacker 
