### PR TITLE
Fix style for areas, nodes, overlay position

### DIFF
--- a/__tests__/utils/__snapshots__/nearest.test.js.snap
+++ b/__tests__/utils/__snapshots__/nearest.test.js.snap
@@ -157,6 +157,7 @@ Object {
       "id": "observe-hauptbanhof",
       "index": 0,
       "location": 0.0018341862152104543,
+      "membership": "no",
       "ways": Object {
         "way/4294967474": null,
       },
@@ -258,6 +259,7 @@ Object {
     "id": "observe-hauptbanhof",
     "index": 0,
     "location": 0.0018341862152104543,
+    "membership": "no",
     "ways": Object {
       "way/4294967474": null,
     },

--- a/app/components/LoadingOverlay.js
+++ b/app/components/LoadingOverlay.js
@@ -1,13 +1,26 @@
 import React from 'react'
 import styled from 'styled-components/native'
 import { colors } from '../style/variables'
+import getPlatformStyles from '../utils/get-platform-styles'
+
+const headerHeight = getPlatformStyles({
+  ios: {
+    height: 80
+  },
+  iphoneX: {
+    height: 100
+  },
+  android: {
+    height: 64
+  }
+})
 
 const Container = styled.View`
   flex: 1;
   justify-content: center;
   position: absolute;
   left: 16;
-  top: 80;
+  top: ${headerHeight.height - 48};
 `
 
 const ActivityIndicator = styled.ActivityIndicator``

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -780,7 +780,7 @@ class Explore extends React.Component {
                       <MapboxGL.LineLayer id='waterLine' filter={filters.waterLine} style={style.osm.waterLine} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='waterFill' filter={filters.waterFill} style={style.osm.waterFill} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='natural' filter={filters.natural} style={style.osm.natural} minZoomLevel={16} />
-                      <MapboxGL.FillLayer id='landuse' filter={filters.landuse} style={style.osm.landuse} minZoomLevel={16} />
+                      <MapboxGL.FillLayer id='landuse' filter={filters.landuse} style={style.osm.landuse} minZoomLevel={12} />
                       <MapboxGL.FillLayer id='leisure' filter={filters.leisure} style={style.osm.leisure} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='allPolygons' filter={filters.allPolygons} style={style.osm.polygons} minZoomLevel={16} />
                       <MapboxGL.FillLayer id='amenities' filter={filters.amenities} style={style.osm.amenities} minZoomLevel={16} />

--- a/app/screens/Explore.js
+++ b/app/screens/Explore.js
@@ -753,8 +753,8 @@ class Explore extends React.Component {
                     onRegionDidChange={this.onRegionDidChange}
                     regionDidChangeDebounceTime={10}
                     onPress={this.onPress}
-                    // compassViewPosition={0}
-                    // compassViewMargins={[16, 16]}
+                    // compassViewPosition={0} requires latest version of react-native-mapbox-gl
+                    compassViewMargins={{ x: 20, y: 148 }}
                   >
                     <MapboxGL.Camera
                       zoomLevel={12}

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -244,7 +244,12 @@ const editingLines = {
 }
 
 const nearestNodes = {
-  circleColor: 'white',
+  circleColor: [
+    'match',
+    ['get', 'membership'],
+    'no', 'red',
+    'white'
+  ],
   circleRadius: 4,
   circleOpacity: 0.5,
   circleStrokeColor: colors.base,

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -211,10 +211,10 @@ const landuse = {
  */
 
 const selectedNode = {
+  circleColor: colors.primary,
   circleRadius: 6,
   circleOpacity: 1,
-  circleColor: 'white',
-  circleStrokeColor: colors.primary,
+  circleStrokeColor: 'white',
   circleStrokeWidth: 2,
   circleStrokeOpacity: 1
 }

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -207,7 +207,7 @@ const landuse = {
     'farmyard', 'rgb(245, 220, 186)',
     '#3fbd30'
   ],
-  fillOpacity: 0.3,
+  fillOpacity: 0.1,
   fillOutlineColor: '#1da01a'
 }
 

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -120,7 +120,7 @@ const waterFill = {
     'riverbank', '#413b7e',
     '#0aa9da'
   ],
-  fillOpacity: 0.3,
+  fillOpacity: 0.25,
   fillOutlineColor: '#0f33a9'
 }
 
@@ -143,7 +143,7 @@ const amenities = {
     'parking', colors.muted,
     'rgba(235, 225, 118, 0.3)'
   ],
-  fillOpacity: 0.3,
+  fillOpacity: 0.25,
   fillOutlineColor: colors.base
 }
 
@@ -162,7 +162,7 @@ const leisure = {
     'swimming_pool', '#0ef',
     '#3fbd30'
   ],
-  fillOpacity: 0.3,
+  fillOpacity: 0.25,
   fillOutlineColor: '#6fd02a'
 }
 
@@ -187,7 +187,7 @@ const natural = {
     'cave_entrance', '#677587',
     '#aDeB50'
   ],
-  fillOpacity: 0.3,
+  fillOpacity: 0.25,
   fillOutlineColor: '#0a42af'
 }
 

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -46,12 +46,7 @@ const lineHighlight = {
 }
 
 const editedLines = {
-  lineWidth: [
-    'interpolate', ['linear'],
-    ['zoom'],
-    16, 6,
-    20, 9
-  ],
+  lineWidth: standardLineWidth,
   lineColor: colors.primary
 }
 

--- a/app/style/map.js
+++ b/app/style/map.js
@@ -126,8 +126,8 @@ const coastline = {
 }
 
 const buildings = {
-  fillColor: colors.base,
-  fillOpacity: 0.2,
+  fillColor: colors.secondary,
+  fillOpacity: 0.3,
   fillOutlineColor: colors.base
 }
 

--- a/app/utils/edit-to-osm-change.js
+++ b/app/utils/edit-to-osm-change.js
@@ -37,7 +37,8 @@ function getTags (feature) {
     'addedNodes',
     'deletedNodes',
     'modifiedNodes',
-    'mergedNodes'
+    'mergedNodes',
+    'membership'
   ]
   return _omit(feature.properties, uninterestingProps)
 }

--- a/app/utils/nearest.js
+++ b/app/utils/nearest.js
@@ -81,6 +81,8 @@ export async function findNearest (node, features) {
 export function findNearestPoint (node, edge) {
   const point = turfNearestPointOnLine(edge, node, { 'units': 'kilometers' })
   point.properties.id = getRandomId()
+  // add a member property to style this node differently
+  point.properties.membership = 'no'
   point.properties.edge = edge
   point.properties.ways = {}
   if (edge.properties.hasOwnProperty('parent_feature')) {


### PR DESCRIPTION
This PR aims to:
- [x] Reduce area, landuse, leisure + nature style opacity
- [x] Increase zoom level for area color rendering
- [x] Move the "loading overlay" and MapboxGL compass in line with other overlay icons
- [x] Fix #271 
