### PR TITLE
Update nearest/selected/edited colors

### DIFF
--- a/app/style/map.js
+++ b/app/style/map.js
@@ -220,9 +220,9 @@ const selectedNode = {
 }
 
 const selectedLine = {
-  lineColor: colors.primary,
+  lineColor: colors.secondary,
   lineOpacity: 0.7,
-  lineWidth: thinLineWidth
+  lineWidth: standardLineWidth
 }
 
 /*
@@ -252,9 +252,14 @@ const nearestNodes = {
   ],
   circleRadius: 4,
   circleOpacity: 0.5,
-  circleStrokeColor: colors.base,
-  circleStrokeWidth: 2,
-  circleStrokeOpacity: 0.5
+  circleStrokeColor: [
+    'match',
+    ['get', 'membership'],
+    'no', 'white',
+    colors.primary
+  ],
+  circleStrokeWidth: 4,
+  circleStrokeOpacity: 1
 }
 
 const nearestLines = {
@@ -277,7 +282,7 @@ const iconHalo = {
 
 const iconEditedHalo = {
   circleRadius: 12,
-  circleColor: colors.primary,
+  circleColor: colors.secondary,
   circleOpacity: 1,
   circleStrokeColor: 'white',
   circleStrokeWidth: 0.5


### PR DESCRIPTION
Updates node/line colors for nearest node, selected node, and edited node:

Edited node:
<img width="271" alt="Screen Shot 2020-06-01 at 10 43 24 AM" src="https://user-images.githubusercontent.com/12634024/83420913-4a794d00-a3f5-11ea-8fed-5b00d0b88990.png">

Nearest node:
<img width="271" alt="Screen Shot 2020-06-01 at 10 44 11 AM" src="https://user-images.githubusercontent.com/12634024/83420888-42211200-a3f5-11ea-9f43-583e184b8c6c.png">
<img width="271" alt="Screen Shot 2020-06-01 at 10 43 59 AM" src="https://user-images.githubusercontent.com/12634024/83420890-43ead580-a3f5-11ea-8146-b8456ca65eca.png">
