### PR TITLE
show way conflict message

### DIFF
--- a/app/components/Conflict.js
+++ b/app/components/Conflict.js
@@ -100,6 +100,17 @@ export default class Conflict extends React.Component {
       </PageWrapper>
     )
   }
+
+  featureIsAWay () {
+    return (
+      <PageWrapper>
+        <Text>
+          Overwriting a conflicting line or area is not currently supported. Discard this edit and fetch latest data.
+        </Text>
+      </PageWrapper>
+    )
+  }
+
   renderDiff (prop) {
     let Fields
     if (prop.newValue) {
@@ -216,6 +227,9 @@ export default class Conflict extends React.Component {
     }
     if (updatedFeature.isDeleted) {
       return this.upstreamDeleted()
+    }
+    if (updatedFeature.geometry.type === 'LineString' || updatedFeature.geometry.type === 'Polygon') {
+      return this.featureIsAWay()
     }
     if (originalEdit.type === 'delete') {
       return this.featureDeleted()

--- a/app/components/Conflict.js
+++ b/app/components/Conflict.js
@@ -228,7 +228,7 @@ export default class Conflict extends React.Component {
     if (updatedFeature.isDeleted) {
       return this.upstreamDeleted()
     }
-    if (updatedFeature.geometry.type === 'LineString' || updatedFeature.geometry.type === 'Polygon') {
+    if (originalEdit.newFeature.wayEditingHistory) {
       return this.featureIsAWay()
     }
     if (originalEdit.type === 'delete') {

--- a/app/screens/UserContributions/UserContributionsItemScreen.js
+++ b/app/screens/UserContributions/UserContributionsItemScreen.js
@@ -206,7 +206,7 @@ class UserContributionsItemScreen extends React.Component {
   }
 
   getHeaderActions (edit) {
-    if (edit.newFeature.geometry.type === 'LineString' || edit.newFeature.geometry.type === 'Polygon') {
+    if (edit.newFeature.wayEditingHistory) {
       return this.getWayConflictActions()
     }
     if (edit.status === 'success') {

--- a/app/screens/UserContributions/UserContributionsItemScreen.js
+++ b/app/screens/UserContributions/UserContributionsItemScreen.js
@@ -196,7 +196,19 @@ class UserContributionsItemScreen extends React.Component {
     ]
   }
 
+  getWayConflictActions () {
+    return [
+      {
+        name: 'trash-bin',
+        onPress: this.discardEdit
+      }
+    ]
+  }
+
   getHeaderActions (edit) {
+    if (edit.newFeature.geometry.type === 'LineString' || edit.newFeature.geometry.type === 'Polygon') {
+      return this.getWayConflictActions()
+    }
     if (edit.status === 'success') {
       return this.getUploadedActions()
     }


### PR DESCRIPTION
This PR will make it so that conflicts on way changes can't be overwritten.

todo:
- [x] change header buttons to just one button for discarding changes
