### PR TITLE
Delete nodeless ways

### DIFF
--- a/app/actions/edit.js
+++ b/app/actions/edit.js
@@ -45,7 +45,15 @@ export function uploadEdits (editIds) {
       try {
         const { changesetId, newNodeIdMap } = await uploadEdit(edit)
         dispatch(editUploaded(edit, changesetId))
-        const feature = edit.type === 'delete' ? edit.oldFeature : edit.newFeature
+
+        let feature
+        if (edit.type === 'delete') {
+          feature = edit.oldFeature
+        } else if (edit.type === 'modify' && edit.newFeature.geometry.type !== 'Point' && edit.newFeature.geometry.coordinates.length < 2) {
+          feature = edit.oldFeature
+        } else {
+          feature = edit.newFeature
+        }
 
         // update the list of modified tiles with ones that touch the feature being uploaded
         featureToTiles(feature).forEach(modifiedTiles.add, modifiedTiles)

--- a/app/actions/edit.js
+++ b/app/actions/edit.js
@@ -48,8 +48,11 @@ export function uploadEdits (editIds) {
 
         let feature
         if (edit.type === 'delete') {
+          // if it's a delete operation, then use oldFeature
           feature = edit.oldFeature
         } else if (edit.type === 'modify' && edit.newFeature.geometry.type !== 'Point' && edit.newFeature.geometry.coordinates.length < 2) {
+          // this is a special case when one of two nodes of a way is deleted, then the way itself is deleted.
+          // in the edits this is considered as a modify operation because it may involve other sharedways. Read for more https://github.com/developmentseed/observe/issues/296
           feature = edit.oldFeature
         } else {
           feature = edit.newFeature

--- a/app/components/WayEditingOverlay.js
+++ b/app/components/WayEditingOverlay.js
@@ -219,8 +219,10 @@ class WayEditingOverlay extends React.Component {
         feature = present.way
       }
 
+      const oldFeature = present.oldFeature
+
       console.log('edited feature', JSON.stringify(feature))
-      this.props.navigation.navigate('EditFeatureDetail', { feature })
+      this.props.navigation.navigate('EditFeatureDetail', { feature: feature, oldFeature: oldFeature })
     }
 
     if (this.props.mode === modes.ADD_WAY && this.props.wayEditingHistory.present.way) {

--- a/app/reducers/wayEditingHistory.js
+++ b/app/reducers/wayEditingHistory.js
@@ -10,14 +10,15 @@ function createDefaultState () {
     movedNodes: [],
     deletedNodes: [],
     mergedNodes: [],
-    modifiedSharedWays: []
+    modifiedSharedWays: [],
+    oldFeature: undefined
   }
 }
 
 function wayEditingHistory (state = createDefaultState(), action) {
   switch (action.type) {
     case types.WAY_EDIT_ENTER: {
-      const { way } = action
+      const { way, feature } = action
       let addedNodes
       let movedNodes
       let deletedNodes
@@ -36,7 +37,8 @@ function wayEditingHistory (state = createDefaultState(), action) {
         movedNodes: movedNodes || state.movedNodes,
         deletedNodes: deletedNodes || state.deletedNodes,
         mergedNodes: mergedNodes || state.mergedNodes,
-        modifiedSharedWays: modifiedSharedWays || state.modifiedSharedWays
+        modifiedSharedWays: modifiedSharedWays || state.modifiedSharedWays,
+        oldFeature: feature
       }
     }
 

--- a/app/screens/Features/EditFeatureDetail.js
+++ b/app/screens/Features/EditFeatureDetail.js
@@ -176,6 +176,7 @@ class EditFeatureDetail extends React.Component {
   saveEditDialog = async (comment) => {
     const { navigation } = this.props
     const { state: { params: { feature } } } = navigation
+    const { state: { params: { oldFeature } } } = navigation
 
     this.cancelEditDialog()
     const changesetComment = comment
@@ -186,7 +187,11 @@ class EditFeatureDetail extends React.Component {
 
     const newFeature = this.getNewFeature()
 
-    this.props.editFeature(feature, newFeature, changesetComment)
+    // for EDIT_WAY mode, the oldFeature is passed down through the navigation
+    // this is because during edit way, we need to update things like ndrefs and that happens in the actions
+    const originalFeature = oldFeature || feature
+
+    this.props.editFeature(originalFeature, newFeature, changesetComment)
     this.props.uploadEdits([feature.id])
 
     navigation.navigate('Explore', { message: 'Your edit is being processed.', mode: modes.EXPLORE })

--- a/app/utils/edit-to-osm-change.js
+++ b/app/utils/edit-to-osm-change.js
@@ -171,11 +171,21 @@ function getComplexChange (edit, changesetId) {
           }
         })
 
-        modifies.push({
-          type: 'way',
-          id: way.properties.id,
-          feature: way
-        })
+        if (way.properties.ndrefs.length < 2) {
+          // if the way now contains less than 2 nodes, delete it
+          deletes.push({
+            type: 'way',
+            id: way.properties.id,
+            feature: way
+          })
+        } else {
+          // in the normal case, push a modify operation
+          modifies.push({
+            type: 'way',
+            id: way.properties.id,
+            feature: way
+          })
+        }
       }
     }
   })
@@ -189,14 +199,23 @@ function getComplexChange (edit, changesetId) {
       feature
     })
   } else if (edit.type === 'modify') {
-    // if feature is modified, we only need to include in change XML if nodes
-    // were added or removed
-    if (wayEditingHistory.addedNodes.length > 0 || wayEditingHistory.deletedNodes.length > 0 || wayEditingHistory.mergedNodes.length > 0) {
+    if (feature.properties.ndrefs.length < 2) {
+      // way does not contain enough nodes, delete it.
+      deletes.push({
+        type: 'way',
+        id: feature.properties.id,
+        feature
+      })
+    } else if (wayEditingHistory.addedNodes.length > 0 || wayEditingHistory.deletedNodes.length > 0 || wayEditingHistory.mergedNodes.length > 0) {
+      // if feature is modified, we only need to include in change XML if nodes
+      // were added or removed
       modifies.push({
         type: 'way',
         id: feature.properties.id,
         feature
       })
+    } else {
+      // if way has only moved nodes, do nothing
     }
   }
 


### PR DESCRIPTION
Fixes #296 partly. Thank you @batpad. One outstanding thing we need to fix in this PR is that in the EditFeatureDetail screen for ways, the old and new features are the same. This results in the tiles not refreshing properly because the geometry is invalid. 