### PR TITLE
Fix overlap preview text

### DIFF
--- a/app/components/MapOverlay.js
+++ b/app/components/MapOverlay.js
@@ -27,8 +27,7 @@ const Drawer = styled(BottomDrawer)`
 `
 
 const FeatureListWrapper = styled.View`
-  margin-top: 16;
-  padding-top: 16;
+  padding-top: 12;
   padding-left: 16;
   padding-right: 16;
   align-self: stretch;
@@ -48,10 +47,13 @@ const ItemList = styled.SectionList`
 `
 
 const Feature = styled.TouchableOpacity`
-  padding-bottom: 24;
+  padding-bottom: 12;
+  padding-top: 12;
   border-bottom-width: 0.5;
   border-bottom-color: ${colors.primary};
   flex: 1;
+  flex-shrink: 0;
+  flex-grow: 0;
   flex-direction: row;
 `
 
@@ -133,7 +135,7 @@ class MapOverlay extends Component {
           <Drawer
             startUp={false}
             containerHeight={300}
-            offset={64}
+            offset={72}
             elevation={10}
           >
             <FeatureListWrapper>


### PR DESCRIPTION
Fixes #188

What's happening here is that the preview doesn't re-render when a node inside a way is selected after the way is selected. While this should probably be fixed by an update to the feature render method, it has been fixed just as well by a css flexbox change.

![proverlaytext](https://user-images.githubusercontent.com/12634024/84103699-d4bb4580-a9e1-11ea-8bd8-1732a6d08290.gif)

... also, unclear how the app determines what feature to list at the top of the list - it seems it may always be the way, and then the node contained therein.